### PR TITLE
Moved select_safe before mutate

### DIFF
--- a/R/gists.R
+++ b/R/gists.R
@@ -90,12 +90,11 @@ gh_gists <- function(
       description = ifelse(as.character(description) == "list()", NA, as.character(description)),
       filenames   = collapse_list(files, "filename"),
       languages   = collapse_list(files, "language"),
-      file_sizes  = collapse_list(files, "size"),
-      created_at  = parse_datetime(created_at),
-      updated_at  = parse_datetime(updated_at)) %>%
+      file_sizes  = collapse_list(files, "size")) %>%
     select_safe(
       id, description, owner_login, created_at, updated_at, comments,
-      filenames, languages, file_sizes, public, url)
+      filenames, languages, file_sizes, public, url) %>%
+    mutate(created_at  = parse_datetime(created_at), updated_at  = parse_datetime(updated_at))
 }
 
 #  FUNCTION: gh_gist_commits ------------------------------------------------------------------
@@ -126,10 +125,10 @@ gh_gist_commits <- function(
 
   gh_url("gists", gist, "commits", api = api) %>%
     gh_page(simplify = TRUE, n_max = n_max, token = token, ...) %>%
-    mutate(committed_at = parse_datetime(committed_at)) %>%
     select_safe(
       version, user_login, committed_at, change_status_total,
-      change_status_additions, change_status_deletions, url)
+      change_status_additions, change_status_deletions, url) %>%
+    mutate(committed_at = parse_datetime(committed_at))
 }
 
 #  FUNCTION: is_gist_starred ------------------------------------------------------------------
@@ -196,8 +195,8 @@ gh_gist_forks <- function(
 
   gh_url("gists", gist, "forks", api = api) %>%
     gh_page(simplify = TRUE, n_max = n_max, token = token, ...) %>%
-    mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at)) %>%
-    select_safe(id, description, owner_login, created_at, updated_at, public, comments, url)
+    select_safe(id, description, owner_login, created_at, updated_at, public, comments, url) %>%
+    mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at))
 }
 
 #  FUNCTION: gh_gist_comment ------------------------------------------------------------------
@@ -258,8 +257,8 @@ gh_gist_comments <- function(
 
   gh_url("gists", gist, "comments", api = api) %>%
     gh_page(simplify = TRUE, n_max = n_max, token = token, ...) %>%
-    mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at)) %>%
-    select_safe(id, body, user_login, created_at, updated_at, url)
+    select_safe(id, body, user_login, created_at, updated_at, url) %>%
+    mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at))
 }
 
 #  FUNCTION: gh_save_gist -------------------------------------------------------------------------

--- a/R/git-data.R
+++ b/R/git-data.R
@@ -168,10 +168,11 @@ gh_git_references <- function(
 
   gh_url("repos", repo, "git/refs", api = api) %>%
     gh_page(simplify = TRUE, n_max = n_max, token = token, ...) %>%
+    select_safe(object_type, object_sha, ref, url) %>%
     mutate(
       name = ifelse(str_detect(ref, "pull"), basename(dirname(ref)), basename(ref)),
       type = ifelse(str_detect(ref, "pull"), ref_map[basename(ref)], ref_map[dirname(ref)])) %>%
-    select_safe(name, type, object_type, object_sha, ref, url)
+    select(name, type, everything())
 }
 
 #  FUNCTION: gh_git_tag -----------------------------------------------------------------------

--- a/R/git-data.R
+++ b/R/git-data.R
@@ -168,11 +168,10 @@ gh_git_references <- function(
 
   gh_url("repos", repo, "git/refs", api = api) %>%
     gh_page(simplify = TRUE, n_max = n_max, token = token, ...) %>%
-    select_safe(object_type, object_sha, ref, url) %>%
+    select_safe(name, type, object_type, object_sha, ref, url) %>%
     mutate(
       name = ifelse(str_detect(ref, "pull"), basename(dirname(ref)), basename(ref)),
-      type = ifelse(str_detect(ref, "pull"), ref_map[basename(ref)], ref_map[dirname(ref)])) %>%
-    select(name, type, everything())
+      type = ifelse(str_detect(ref, "pull"), ref_map[basename(ref)], ref_map[dirname(ref)]))
 }
 
 #  FUNCTION: gh_git_tag -----------------------------------------------------------------------

--- a/R/issues.R
+++ b/R/issues.R
@@ -102,13 +102,14 @@ gh_issues <- function(
     gh_page(simplify = TRUE, n_max = n_max, token = token, ...) %>%
     mutate(
       labels     = collapse_list(labels, "name"),
-      assignees  = collapse_list(assignees, "login"),
-      created_at = parse_datetime(created_at),
-      updated_at = parse_datetime(updated_at),
-      closed_at  = parse_datetime(closed_at)) %>%
+      assignees  = collapse_list(assignees, "login")) %>%
     select_safe(
       number, title, body, state, user_login, labels, assignees,
-      milestone_number, milestone_title, created_at, updated_at, closed_at)
+      milestone_number, milestone_title, created_at, updated_at, closed_at) %>%
+    mutate(
+      created_at = parse_datetime(created_at),
+      updated_at = parse_datetime(updated_at),
+      closed_at  = parse_datetime(closed_at))
 }
 
 #  FUNCTION: gh_user_issues -------------------------------------------------------------------
@@ -182,13 +183,11 @@ gh_user_issues <- function(
     direction = direction,
     since     = since) %>%
     gh_page(simplify = TRUE, n_max = n_max, token = token, ...) %>%
-    mutate(
-      labels     = collapse_list(labels, "name"),
-      created_at = parse_datetime(created_at),
-      updated_at = parse_datetime(updated_at)) %>%
+    mutate(labels = collapse_list(labels, "name")) %>%
     select_safe(
       number, title, body, state, user_login, labels, assignee_login,
-      milestone_number, milestone_title, created_at, updated_at, repository_name)
+      milestone_number, milestone_title, created_at, updated_at, repository_name) %>%
+    mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at))
 }
 
 #  FUNCTION: gh_assignees ---------------------------------------------------------------------
@@ -273,8 +272,8 @@ gh_issue_comments <- function(
       html_url   = character())
   } else {
     comments %>%
-      mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at)) %>%
-      select_safe(id, body, user_login, created_at, updated_at, html_url)
+      select_safe(id, body, user_login, created_at, updated_at, html_url) %>%
+      mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at))
   }
 }
 
@@ -459,13 +458,13 @@ gh_milestones <- function(
     "repos", repo, "milestones", api = api,
     state = state, sort = sort, direction = direction) %>%
     gh_page(simplify = TRUE, n_max = n_max, token = token, ...) %>%
+    select_safe(
+      id, number, title, description, creator_login, open_issues,
+      closed_issues, state, created_at, updated_at, url) %>%
     mutate(
       number     = as.integer(number),
       created_at = parse_datetime(created_at),
-      updated_at = parse_datetime(updated_at)) %>%
-    select_safe(
-      id, number, title, description, creator_login, open_issues,
-      closed_issues, state, created_at, updated_at, url)
+      updated_at = parse_datetime(updated_at))
 }
 
 #  FUNCTION: gh_event -------------------------------------------------------------------------
@@ -537,6 +536,6 @@ gh_events <- function(
 
   url %>%
     gh_page(simplify = TRUE, n_max = n_max, token = token, ...) %>%
-    mutate(created_at = parse_datetime(created_at)) %>%
-    select_safe(id, event, issue_number, issue_title, created_at, actor_login, commit_id, url)
+    select_safe(id, event, issue_number, issue_title, created_at, actor_login, commit_id, url) %>%
+    mutate(created_at = parse_datetime(created_at))
 }

--- a/R/projects.R
+++ b/R/projects.R
@@ -76,8 +76,8 @@ gh_projects <- function(
     gh_page(
       simplify = TRUE, accept = "application/vnd.github.inertia-preview+json",
       n_max = n_max, token = token, ...) %>%
-    mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at)) %>%
-    select_safe(id, number, name, body, state, creator_login, created_at, updated_at, url)
+    select_safe(id, number, name, body, state, creator_login, created_at, updated_at, url) %>%
+    mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at))
 }
 
 #  FUNCTION: gh_column ------------------------------------------------------------------------
@@ -139,8 +139,8 @@ gh_columns <- function(
     gh_page(
       simplify = TRUE, accept = "application/vnd.github.inertia-preview+json",
       n_max = n_max, token = token, ...) %>%
-    mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at)) %>%
-    select_safe(id, name, created_at, updated_at, url)
+    select_safe(id, name, created_at, updated_at, url) %>%
+    mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at))
 }
 
 #  FUNCTION: gh_card --------------------------------------------------------------------------
@@ -202,6 +202,6 @@ gh_cards <- function(
     gh_page(
       simplify = TRUE, accept = "application/vnd.github.inertia-preview+json",
       n_max = n_max, token = token, ...) %>%
-    mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at)) %>%
-    select_safe(id, creator_login, created_at, updated_at, content_url, url)
+    select_safe(id, creator_login, created_at, updated_at, content_url, url) %>%
+    mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at))
 }

--- a/R/pull-requests.R
+++ b/R/pull-requests.R
@@ -77,14 +77,14 @@ gh_pull_requests <- function(
     "repos", repo, "pulls", api = api,
     state = state, head = head, base = base, sort = sort, direction = direction) %>%
     gh_page(simplify = TRUE, n_max = n_max, token = token, ...) %>%
+    select_safe(
+      id, number, title, body, user_login, state, created_at, updated_at, closed_at, merged_at,
+      merge_commit_sha, head_ref, head_sha, head_user_login, head_repo_full_name, locked, url) %>%
     mutate(
       created_at = parse_datetime(created_at),
       updated_at = parse_datetime(updated_at),
       closed_at  = parse_datetime(closed_at),
-      merged_at  = parse_datetime(merged_at)) %>%
-    select_safe(
-      id, number, title, body, user_login, state, created_at, updated_at, closed_at, merged_at,
-      merge_commit_sha, head_ref, head_sha, head_user_login, head_repo_full_name, locked, url)
+      merged_at  = parse_datetime(merged_at))
 }
 
 #  FUNCTION: gh_pull_commits ------------------------------------------------------------------
@@ -119,10 +119,9 @@ gh_pull_commits <- function(
 
   gh_url("repos", repo, "pulls", pull_request, "commits", api = api) %>%
     gh_page(simplify = TRUE, n_max = n_max, token = token, ...) %>%
-    mutate(
-      commit_date = parse_datetime(commit_author_date),
-      parents_sha = collapse_list(parents, "sha")) %>%
-    select_safe(sha, author_login, commit_date, commit_message, url, parents_sha)
+    mutate(parents_sha = collapse_list(parents, "sha")) %>%
+    select_safe(sha, author_login, commit_date, commit_message, url, parents_sha) %>%
+    mutate(commit_date = parse_datetime(commit_author_date))
 }
 
 #  FUNCTION: gh_pull_files --------------------------------------------------------------------

--- a/R/pull-requests.R
+++ b/R/pull-requests.R
@@ -120,8 +120,8 @@ gh_pull_commits <- function(
   gh_url("repos", repo, "pulls", pull_request, "commits", api = api) %>%
     gh_page(simplify = TRUE, n_max = n_max, token = token, ...) %>%
     mutate(parents_sha = collapse_list(parents, "sha")) %>%
-    select_safe(sha, author_login, commit_date, commit_message, url, parents_sha) %>%
-    mutate(commit_date = parse_datetime(commit_author_date))
+    select_safe(sha, author_login, commit_date = commit_author_date, commit_message, url, parents_sha) %>%
+    mutate(commit_date = parse_datetime(commit_date))
 }
 
 #  FUNCTION: gh_pull_files --------------------------------------------------------------------

--- a/R/repositories.R
+++ b/R/repositories.R
@@ -417,10 +417,9 @@ gh_commits <- function(
     select(starts_with("commit_")) %>%
     set_names(str_replace(names(.), "^commit_", "")) %>%
     select_safe(
-      message, url, author_name, author_email, committer_name,
-      committer_email, tree_sha, tree_url) %>%
-    mutate(sha = basename(url), date = parse_datetime(author_date)) %>%
-    select(sha, date, everything())
+      sha, date = author_date, message, url, author_name, author_email,
+      committer_name, committer_email, tree_sha, tree_url) %>%
+    mutate(sha = basename(url), date = parse_datetime(date))
 }
 
 #  FUNCTION: gh_compare_commits ---------------------------------------------------------------
@@ -458,10 +457,9 @@ gh_compare_commits <- function(
     select(starts_with("commit_")) %>%
     set_names(str_replace(names(.), "^commit_", "")) %>%
     select_safe(
-      message, url, author_name,author_email,
-      committer_name, committer_email) %>%
-    mutate(sha = basename(url), date = parse_datetime(author_date)) %>%
-    select(sha, date, everything())
+      sha, date = author_date, message, url, author_name,
+      author_email, committer_name, committer_email) %>%
+    mutate(sha = basename(url), date = parse_datetime(date))
 }
 
 #  FUNCTION: gh_compare_files -----------------------------------------------------------------

--- a/R/repositories.R
+++ b/R/repositories.R
@@ -133,12 +133,10 @@ gh_repositories <- function(
   }
 
   repos %>%
-    mutate(
-      created_at = parse_datetime(created_at),
-      updated_at = parse_datetime(updated_at)) %>%
     select_safe(
       name, owner_login, owner_type, description, html_url, url,
-      created_at, updated_at, size, open_issues, default_branch)
+      created_at, updated_at, size, open_issues, default_branch) %>%
+    mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at))
 }
 
 #  FUNCTION: gh_tags --------------------------------------------------------------------------
@@ -418,10 +416,11 @@ gh_commits <- function(
     gh_page(simplify = TRUE, n_max = n_max, token = token, ...) %>%
     select(starts_with("commit_")) %>%
     set_names(str_replace(names(.), "^commit_", "")) %>%
-    mutate(sha = basename(url), date = parse_datetime(author_date)) %>%
     select_safe(
-      sha, date, message, url, author_name, author_email,
-      committer_name, committer_email, tree_sha, tree_url)
+      message, url, author_name, author_email, committer_name,
+      committer_email, tree_sha, tree_url) %>%
+    mutate(sha = basename(url), date = parse_datetime(author_date)) %>%
+    select(sha, date, everything())
 }
 
 #  FUNCTION: gh_compare_commits ---------------------------------------------------------------
@@ -458,10 +457,11 @@ gh_compare_commits <- function(
     gh_get(sub_list = "commits", simplify = TRUE, token = token, ...) %>%
     select(starts_with("commit_")) %>%
     set_names(str_replace(names(.), "^commit_", "")) %>%
-    mutate(sha = basename(url), date = parse_datetime(author_date)) %>%
     select_safe(
-      sha, date, message, url, author_name,
-      author_email, committer_name, committer_email)
+      message, url, author_name,author_email,
+      committer_name, committer_email) %>%
+    mutate(sha = basename(url), date = parse_datetime(author_date)) %>%
+    select(sha, date, everything())
 }
 
 #  FUNCTION: gh_compare_files -----------------------------------------------------------------
@@ -799,8 +799,8 @@ gh_commit_comments <- function(
 
   url %>%
     gh_page(simplify = TRUE, n_max = n_max, token = token, ...) %>%
-    mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at)) %>%
-    select_safe(id, commit_id, body, user_login, created_at, updated_at, position, line, path, url)
+    select_safe(id, commit_id, body, user_login, created_at, updated_at, position, line, path, url) %>%
+    mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at))
 }
 
 #  FUNCTION: gh_contributers ------------------------------------------------------------------
@@ -936,13 +936,11 @@ gh_releases <- function(
 
   gh_url("repos", repo, "releases", api = api) %>%
     gh_page(simplify = TRUE, n_max = n_max, token = token, ...) %>%
-    mutate(
-      assets = collapse_list(assets, "name"),
-      created_at = parse_datetime(created_at),
-      published_at = parse_datetime(published_at)) %>%
+    mutate(assets = collapse_list(assets, "name")) %>%
     select_safe(
       id, tag_name, name, body, author_login, draft, prerelease, target_commitish,
-      created_at, published_at, assets, zipball_url, url)
+      created_at, published_at, assets, zipball_url, url) %>%
+    mutate(created_at = parse_datetime(created_at), published_at = parse_datetime(published_at))
 }
 
 #  FUNCTION: gh_asset -------------------------------------------------------------------------
@@ -1007,8 +1005,8 @@ gh_assets <- function(
 
   gh_url("repos", repo, "releases", release, "assets", api = api) %>%
     gh_page(simplify = TRUE, n_max = n_max, token = token, ...) %>%
-    mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at)) %>%
     select_safe(
       id, name, label, content_type, state, size, download_count,
-      created_at, updated_at, uploader_login, url)
+      created_at, updated_at, uploader_login, url) %>%
+    mutate(created_at = parse_datetime(created_at), updated_at = parse_datetime(updated_at))
 }


### PR DESCRIPTION
This is required because if a column does not exist the mutate fails. So, using select_safe first ensures the column always exists.