### PR TITLE
159 team projects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: githapi
 Title: User-friendly access to the GitHub API for R, consistent with the tidyverse
-Version: 0.9.9
+Version: 0.9.10
 Authors@R: person("Chad", "Goymer", email = "chad.goymer@lloyds.com", role = c("aut", "cre"))
 Description: Provides a suite of functions which simplify working with GitHub's API.
 Imports:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# githapi 0.9.10
+
+Update the following functions:
+- `create_project()`: Only include organization properties if organization project is created
+- `update_project()`: Add or update team permissions on an organization project
+- `view_projects()`: View the projects a team has access to
+- `view_project()`: View a project a team has access to
+- `browse_project()`: Browse a project a team has access to
+- `delete_project()`: Remove a team from an organization project
+
 # githapi 0.9.9
 
 Added the following functions:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # githapi 0.9.10
 
-Update the following functions:
+Updated the following functions:
 - `create_project()`: Only include organization properties if organization project is created
 - `update_project()`: Add or update team permissions on an organization project
 - `view_projects()`: View the projects a team has access to

--- a/R/cards.R
+++ b/R/cards.R
@@ -370,7 +370,6 @@ move_card <- function(
 #'     user    = "ChadGoymer")
 #'
 #'   # View cards in an organization's project
-#'   view_card(
 #'   cards <- view_cards(
 #'     column  = "Test cards",
 #'     project = "Test cards",

--- a/R/github-api.R
+++ b/R/github-api.R
@@ -523,7 +523,7 @@ gh_find <- function(
       str_remove("<")
   }
 
-  error("Could not find an entity with the specified value, '", value, "', for the specified property '", property, "'")
+  error("Could not find an entity with '", property, "' equal to '", value, "'")
 
 }
 

--- a/R/projects.R
+++ b/R/projects.R
@@ -617,6 +617,7 @@ browse_project <- function(
   project,
   repo,
   user,
+  team,
   org,
   ...)
 {
@@ -624,6 +625,7 @@ browse_project <- function(
     project = project,
     repo    = repo,
     user    = user,
+    team    = team,
     org     = org,
     ...)
 

--- a/R/projects.R
+++ b/R/projects.R
@@ -29,6 +29,9 @@
 #' - **name**: The name given to the project.
 #' - **body**: The description given to the project.
 #' - **state**: Whether the project is "open" or "closed".
+#' - **private**: Whether the project is private (organisation project only).
+#' - **org_permission**: The default permission for the project - either "read", "write" or
+#'   "admin" (organisation project only).
 #' - **creator**: The user who created the project.
 #' - **created_at**: When it was created.
 #' - **updated_at**: When it was last updated.
@@ -49,8 +52,8 @@
 #'
 #'   # Create a project for an organization
 #'   create_project(
-#'     name = "Repo project",
-#'     body = "This is a repository's project",
+#'     name = "Organization project",
+#'     body = "This is an organization's project",
 #'     org  = "HairyCoos")
 #' }
 #'
@@ -94,8 +97,22 @@ create_project <- function(
   info("Transforming results", level = 4)
   project_gh <- select_properties(project_lst, properties$project)
 
+  if (!missing(org))
+  {
+    project_gh <- project_gh %>%
+      append(
+        after = which(names(project_gh) == "state"),
+        list(private = project_lst$private, org_permission = project_lst$organization_permission))
+  }
+
   info("Done", level = 7)
-  project_gh
+  structure(
+    project_gh,
+    class   = class(project_lst),
+    url     = attr(project_lst, "url"),
+    request = attr(project_lst, "request"),
+    status  = attr(project_lst, "status"),
+    header  = attr(project_lst, "header"))
 }
 
 

--- a/R/properties.R
+++ b/R/properties.R
@@ -13,8 +13,6 @@ properties <- list(
     name                                     = c("name",                                     as = "character"),
     body                                     = c("body",                                     as = "character"),
     state                                    = c("state",                                    as = "character"),
-    permission                               = c("organization_permission",                  as = "character"),
-    private                                  = c("private",                                  as = "logical"),
     creator                                  = c("creator", "login",                         as = "character"),
     created_at                               = c("created_at",                               as = "datetime"),
     updated_at                               = c("updated_at",                               as = "datetime"),

--- a/docs/404.html
+++ b/docs/404.html
@@ -67,7 +67,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -67,7 +67,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -67,7 +67,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -67,7 +67,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -67,7 +67,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/news/news-0.2.html
+++ b/docs/news/news-0.2.html
@@ -67,7 +67,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/news/news-0.3.html
+++ b/docs/news/news-0.3.html
@@ -67,7 +67,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/news/news-0.4.html
+++ b/docs/news/news-0.4.html
@@ -67,7 +67,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/news/news-0.5.html
+++ b/docs/news/news-0.5.html
@@ -67,7 +67,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/news/news-0.6.html
+++ b/docs/news/news-0.6.html
@@ -67,7 +67,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/news/news-0.7.html
+++ b/docs/news/news-0.7.html
@@ -67,7 +67,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/news/news-0.8.html
+++ b/docs/news/news-0.8.html
@@ -67,7 +67,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/news/news-0.9.html
+++ b/docs/news/news-0.9.html
@@ -67,7 +67,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 
@@ -290,6 +290,25 @@
 <li><code><a href="../reference/is_manager.html">is_manager()</a></code></li>
 </ul>
 </div>
+    <div id="githapi-0910" class="section level1">
+<h1 class="page-header">
+<a href="#githapi-0910" class="anchor"></a>githapi 0.9.10</h1>
+<p>Update the following functions:</p>
+<ul>
+<li>
+<code><a href="../reference/create_project.html">create_project()</a></code>: Only include organization properties if organization project is created</li>
+<li>
+<code><a href="../reference/update_project.html">update_project()</a></code>: Add or update team permissions on an organization project</li>
+<li>
+<code><a href="../reference/view_projects.html">view_projects()</a></code>: View the projects a team has access to</li>
+<li>
+<code><a href="../reference/view_projects.html">view_project()</a></code>: View a project a team has access to</li>
+<li>
+<code><a href="../reference/view_projects.html">browse_project()</a></code>: Browse a project a team has access to</li>
+<li>
+<code><a href="../reference/delete_project.html">delete_project()</a></code>: Remove a team from an organization project</li>
+</ul>
+</div>
   </div>
 
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
@@ -306,6 +325,7 @@
         <li><a href="#githapi-097">0.9.7</a></li>
         <li><a href="#githapi-098">0.9.8</a></li>
         <li><a href="#githapi-099">0.9.9</a></li>
+        <li><a href="#githapi-0910">0.9.10</a></li>
       </ul>
     </div>
   </div>

--- a/docs/pull_request_template.html
+++ b/docs/pull_request_template.html
@@ -67,7 +67,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/blobs_exist.html
+++ b/docs/reference/blobs_exist.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/branches_exist.html
+++ b/docs/reference/branches_exist.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/commits_exist.html
+++ b/docs/reference/commits_exist.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/compare_commits.html
+++ b/docs/reference/compare_commits.html
@@ -72,7 +72,7 @@ view_commits()." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/compare_files.html
+++ b/docs/reference/compare_files.html
@@ -70,7 +70,7 @@ commits. The commits can be specified by any git reference, i.e. branch, tag or 
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/create_blobs.html
+++ b/docs/reference/create_blobs.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/create_branches.html
+++ b/docs/reference/create_branches.html
@@ -70,7 +70,7 @@ GitHub." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/create_card.html
+++ b/docs/reference/create_card.html
@@ -70,7 +70,7 @@ card can either contain an existing issue or pull request or you can create a no
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/create_column.html
+++ b/docs/reference/create_column.html
@@ -70,7 +70,7 @@ will need to add cards separately." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/create_commit.html
+++ b/docs/reference/create_commit.html
@@ -71,7 +71,7 @@ least one parent commit must be specified." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/create_files.html
+++ b/docs/reference/create_files.html
@@ -71,7 +71,7 @@ committer and author can be set explicitly if necessary." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/create_project.html
+++ b/docs/reference/create_project.html
@@ -70,7 +70,7 @@ to add columns and cards separately." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 
@@ -155,6 +155,9 @@ to add columns and cards separately.</p>
 <li><p><strong>name</strong>: The name given to the project.</p></li>
 <li><p><strong>body</strong>: The description given to the project.</p></li>
 <li><p><strong>state</strong>: Whether the project is "open" or "closed".</p></li>
+<li><p><strong>private</strong>: Whether the project is private (organisation project only).</p></li>
+<li><p><strong>org_permission</strong>: The default permission for the project - either "read", "write" or
+"admin" (organisation project only).</p></li>
 <li><p><strong>creator</strong>: The user who created the project.</p></li>
 <li><p><strong>created_at</strong>: When it was created.</p></li>
 <li><p><strong>updated_at</strong>: When it was last updated.</p></li>
@@ -188,8 +191,8 @@ or organization is specified the project is created for the authenticated user.<
 
   <span class='co'># Create a project for an organization</span>
   <span class='fu'>create_project</span>(
-    <span class='kw'>name</span> <span class='kw'>=</span> <span class='st'>"Repo project"</span>,
-    <span class='kw'>body</span> <span class='kw'>=</span> <span class='st'>"This is a repository's project"</span>,
+    <span class='kw'>name</span> <span class='kw'>=</span> <span class='st'>"Organization project"</span>,
+    <span class='kw'>body</span> <span class='kw'>=</span> <span class='st'>"This is an organization's project"</span>,
     <span class='kw'>org</span>  <span class='kw'>=</span> <span class='st'>"HairyCoos"</span>)
 }</div></pre>
   </div>

--- a/docs/reference/create_releases.html
+++ b/docs/reference/create_releases.html
@@ -71,7 +71,7 @@ releases are draft and whether they are pre-releases." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/create_tags.html
+++ b/docs/reference/create_tags.html
@@ -70,7 +70,7 @@ GitHub." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/create_team.html
+++ b/docs/reference/create_team.html
@@ -71,7 +71,7 @@ team." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/create_tree.html
+++ b/docs/reference/create_tree.html
@@ -72,7 +72,7 @@ using this function to create trees." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/delete_branches.html
+++ b/docs/reference/delete_branches.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/delete_card.html
+++ b/docs/reference/delete_card.html
@@ -70,7 +70,7 @@ recoverable. Instead, you may way to archive the card with update_card()." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/delete_column.html
+++ b/docs/reference/delete_column.html
@@ -70,7 +70,7 @@ recoverable." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/delete_files.html
+++ b/docs/reference/delete_files.html
@@ -71,7 +71,7 @@ committer and author can be set explicitly if necessary." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/delete_project.html
+++ b/docs/reference/delete_project.html
@@ -70,7 +70,7 @@ recoverable. If you just want to close the project use update_project()." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 
@@ -119,7 +119,7 @@ recoverable. If you just want to close the project use update_project()." />
 recoverable. If you just want to close the project use <code><a href='update_project.html'>update_project()</a></code>.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>delete_project</span>(<span class='no'>project</span>, <span class='no'>repo</span>, <span class='no'>user</span>, <span class='no'>org</span>, <span class='no'>...</span>)</pre>
+    <pre class="usage"><span class='fu'>delete_project</span>(<span class='no'>project</span>, <span class='no'>repo</span>, <span class='no'>user</span>, <span class='no'>team</span>, <span class='no'>org</span>, <span class='no'>...</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -137,6 +137,10 @@ recoverable. If you just want to close the project use <code><a href='update_pro
       <td><p>(string, optional) The login of the user.</p></td>
     </tr>
     <tr>
+      <th>team</th>
+      <td><p>(string or integer, optional) The team ID or name.</p></td>
+    </tr>
+    <tr>
       <th>org</th>
       <td><p>(string, optional) The name of the organization.</p></td>
     </tr>
@@ -151,10 +155,13 @@ recoverable. If you just want to close the project use <code><a href='update_pro
     <p><code>delete_project()</code> returns a TRUE if successfully deleted.</p>
     <h2 class="hasAnchor" id="details"><a class="anchor" href="#details"></a>Details</h2>
 
-    <p>You can delete a project associated with either a repository, user or organization, by
-supplying them as an input, as long as you have appropriate permissions.</p>
+    <p>You can delete a project associated with either a repository, user, team or organization,
+by supplying them as an input, as long as you have appropriate permissions. Deleting a
+team project just removes the team's access. If you want to delete it completely you
+have to delete the organization's project.</p>
 <p>For more details see the GitHub API documentation:</p><ul>
 <li><p><a href='https://developer.github.com/v3/projects/#delete-a-project'>https://developer.github.com/v3/projects/#delete-a-project</a></p></li>
+<li><p><a href='https://developer.github.com/v3/teams/#remove-team-project'>https://developer.github.com/v3/teams/#remove-team-project</a></p></li>
 </ul>
 
 
@@ -169,6 +176,12 @@ supplying them as an input, as long as you have appropriate permissions.</p>
   <span class='fu'>delete_project</span>(
     <span class='kw'>project</span> <span class='kw'>=</span> <span class='st'>"User project"</span>,
     <span class='kw'>user</span>    <span class='kw'>=</span> <span class='st'>"ChadGoymer"</span>)
+
+  <span class='co'># Remove a team's access to the organization's project</span>
+  <span class='fu'>delete_project</span>(
+    <span class='kw'>project</span> <span class='kw'>=</span> <span class='st'>"User project"</span>,
+    <span class='kw'>team</span>    <span class='kw'>=</span> <span class='st'>"HeadCoos"</span>,
+    <span class='kw'>org</span>     <span class='kw'>=</span> <span class='st'>"HairyCoos"</span>)
 
   <span class='co'># Delete a project for an organization</span>
   <span class='fu'>delete_project</span>(

--- a/docs/reference/delete_releases.html
+++ b/docs/reference/delete_releases.html
@@ -70,7 +70,7 @@ releases from the repository." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/delete_tags.html
+++ b/docs/reference/delete_tags.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/delete_team.html
+++ b/docs/reference/delete_team.html
@@ -70,7 +70,7 @@ appropriate permissions. Care should be taken as it will not be recoverable." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/download_commit.html
+++ b/docs/reference/download_commit.html
@@ -71,7 +71,7 @@ be specified by a branch, tag or SHA." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/download_files.html
+++ b/docs/reference/download_files.html
@@ -71,7 +71,7 @@ size." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/files_exist.html
+++ b/docs/reference/files_exist.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_asset.html
+++ b/docs/reference/gh_asset.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_assets.html
+++ b/docs/reference/gh_assets.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_assignees.html
+++ b/docs/reference/gh_assignees.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_branch.html
+++ b/docs/reference/gh_branch.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_branches.html
+++ b/docs/reference/gh_branches.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_card.html
+++ b/docs/reference/gh_card.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_cards.html
+++ b/docs/reference/gh_cards.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_collaborators.html
+++ b/docs/reference/gh_collaborators.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_column.html
+++ b/docs/reference/gh_column.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_columns.html
+++ b/docs/reference/gh_columns.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_commit.html
+++ b/docs/reference/gh_commit.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_commit_comment.html
+++ b/docs/reference/gh_commit_comment.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_commit_comments.html
+++ b/docs/reference/gh_commit_comments.html
@@ -70,7 +70,7 @@ https://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repos
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_commit_sha.html
+++ b/docs/reference/gh_commit_sha.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_commits.html
+++ b/docs/reference/gh_commits.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_compare_commits.html
+++ b/docs/reference/gh_compare_commits.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_compare_files.html
+++ b/docs/reference/gh_compare_files.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_contents.html
+++ b/docs/reference/gh_contents.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_contributers.html
+++ b/docs/reference/gh_contributers.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_download.html
+++ b/docs/reference/gh_download.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_download_binary.html
+++ b/docs/reference/gh_download_binary.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_event.html
+++ b/docs/reference/gh_event.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_events.html
+++ b/docs/reference/gh_events.html
@@ -70,7 +70,7 @@ https://developer.github.com/v3/issues/events/#list-events-for-an-issue" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_find.html
+++ b/docs/reference/gh_find.html
@@ -71,7 +71,7 @@ specifying the title." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_get.html
+++ b/docs/reference/gh_get.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_gist.html
+++ b/docs/reference/gh_gist.html
@@ -70,7 +70,7 @@ https://developer.github.com/v3/gists/#get-a-specific-revision-of-a-gist" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_gist_comment.html
+++ b/docs/reference/gh_gist_comment.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_gist_comments.html
+++ b/docs/reference/gh_gist_comments.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_gist_commits.html
+++ b/docs/reference/gh_gist_commits.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_gist_forks.html
+++ b/docs/reference/gh_gist_forks.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_gists.html
+++ b/docs/reference/gh_gists.html
@@ -72,7 +72,7 @@ https://developer.github.com/v3/gists/#list-starred-gists" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_git_blob.html
+++ b/docs/reference/gh_git_blob.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_git_commit.html
+++ b/docs/reference/gh_git_commit.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_git_reference.html
+++ b/docs/reference/gh_git_reference.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_git_references.html
+++ b/docs/reference/gh_git_references.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_git_tag.html
+++ b/docs/reference/gh_git_tag.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_git_tree.html
+++ b/docs/reference/gh_git_tree.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_issue.html
+++ b/docs/reference/gh_issue.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_issue_comment.html
+++ b/docs/reference/gh_issue_comment.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_issue_comments.html
+++ b/docs/reference/gh_issue_comments.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_issues.html
+++ b/docs/reference/gh_issues.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_label.html
+++ b/docs/reference/gh_label.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_labels.html
+++ b/docs/reference/gh_labels.html
@@ -71,7 +71,7 @@ https://developer.github.com/v3/issues/labels/#list-all-labels-for-this-reposito
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_languages.html
+++ b/docs/reference/gh_languages.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_members.html
+++ b/docs/reference/gh_members.html
@@ -70,7 +70,7 @@ https://developer.github.com/v3/orgs/teams/#list-team-members" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_membership.html
+++ b/docs/reference/gh_membership.html
@@ -70,7 +70,7 @@ https://developer.github.com/v3/orgs/teams/#get-team-membership" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_memberships.html
+++ b/docs/reference/gh_memberships.html
@@ -70,7 +70,7 @@ https://developer.github.com/v3/orgs/members/#get-your-organization-membership" 
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_milestone.html
+++ b/docs/reference/gh_milestone.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_milestones.html
+++ b/docs/reference/gh_milestones.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_organization.html
+++ b/docs/reference/gh_organization.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_organizations.html
+++ b/docs/reference/gh_organizations.html
@@ -70,7 +70,7 @@ https://developer.github.com/v3/orgs/#list-user-organizations" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_page.html
+++ b/docs/reference/gh_page.html
@@ -71,7 +71,7 @@ Each page uses gh_request() to retrieve the contents." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_permissions.html
+++ b/docs/reference/gh_permissions.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_project.html
+++ b/docs/reference/gh_project.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_projects.html
+++ b/docs/reference/gh_projects.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_pull_comment.html
+++ b/docs/reference/gh_pull_comment.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_pull_comments.html
+++ b/docs/reference/gh_pull_comments.html
@@ -71,7 +71,7 @@ https://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository" /
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_pull_commits.html
+++ b/docs/reference/gh_pull_commits.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_pull_files.html
+++ b/docs/reference/gh_pull_files.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_pull_request.html
+++ b/docs/reference/gh_pull_request.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_pull_requests.html
+++ b/docs/reference/gh_pull_requests.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_pull_review.html
+++ b/docs/reference/gh_pull_review.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_pull_review_requests.html
+++ b/docs/reference/gh_pull_review_requests.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_pull_reviews.html
+++ b/docs/reference/gh_pull_reviews.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_readme.html
+++ b/docs/reference/gh_readme.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_release.html
+++ b/docs/reference/gh_release.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_releases.html
+++ b/docs/reference/gh_releases.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_repositories.html
+++ b/docs/reference/gh_repositories.html
@@ -71,7 +71,7 @@ https://developer.github.com/v3/orgs/teams/#list-team-repos" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_repository.html
+++ b/docs/reference/gh_repository.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_request.html
+++ b/docs/reference/gh_request.html
@@ -70,7 +70,7 @@ the specified URL." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_save.html
+++ b/docs/reference/gh_save.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_save_gist.html
+++ b/docs/reference/gh_save_gist.html
@@ -70,7 +70,7 @@ https://developer.github.com/v3/gists/#get-a-specific-revision-of-a-gist" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_source.html
+++ b/docs/reference/gh_source.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_source_gist.html
+++ b/docs/reference/gh_source_gist.html
@@ -70,7 +70,7 @@ https://developer.github.com/v3/gists/#get-a-specific-revision-of-a-gist" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_tags.html
+++ b/docs/reference/gh_tags.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_team.html
+++ b/docs/reference/gh_team.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_teams.html
+++ b/docs/reference/gh_teams.html
@@ -70,7 +70,7 @@ https://developer.github.com/v3/orgs/teams/#list-user-teams" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_token.html
+++ b/docs/reference/gh_token.html
@@ -72,7 +72,7 @@ calls to the githapi API." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 
@@ -175,7 +175,7 @@ the cache uses the httr default; if <code>FALSE</code> it does not cache. Can be
 
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
-    <p>A token which is either a string, for a personal access token, or a <a href='https://httr.r-lib.org/reference/Token-class.html'>httr::Token</a>
+    <p>A token which is either a string, for a personal access token, or a <a href='https://rdrr.io/pkg/httr/man/Token-class.html'>httr::Token</a>
 object for an OAuth token.</p>
     <h2 class="hasAnchor" id="details"><a class="anchor" href="#details"></a>Details</h2>
 

--- a/docs/reference/gh_url.html
+++ b/docs/reference/gh_url.html
@@ -71,7 +71,7 @@ queries." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_user.html
+++ b/docs/reference/gh_user.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_user_email.html
+++ b/docs/reference/gh_user_email.html
@@ -70,7 +70,7 @@ https://developer.github.com/v3/users/emails/#list-public-email-addresses-for-a-
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_user_issues.html
+++ b/docs/reference/gh_user_issues.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/gh_users.html
+++ b/docs/reference/gh_users.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/githapi-deprecated.html
+++ b/docs/reference/githapi-deprecated.html
@@ -70,7 +70,7 @@ possible, alternative functions with similar functionality are also mentioned." 
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/githapi.html
+++ b/docs/reference/githapi.html
@@ -71,7 +71,7 @@ collections." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -67,7 +67,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/is_branch.html
+++ b/docs/reference/is_branch.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/is_collaborator.html
+++ b/docs/reference/is_collaborator.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/is_gist_starred.html
+++ b/docs/reference/is_gist_starred.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/is_manager.html
+++ b/docs/reference/is_manager.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/is_member.html
+++ b/docs/reference/is_member.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/is_pull_merged.html
+++ b/docs/reference/is_pull_merged.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/is_repo.html
+++ b/docs/reference/is_repo.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/is_repository.html
+++ b/docs/reference/is_repository.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/is_sha.html
+++ b/docs/reference/is_sha.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/is_tag.html
+++ b/docs/reference/is_tag.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/is_valid_sha.html
+++ b/docs/reference/is_valid_sha.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/read_files.html
+++ b/docs/reference/read_files.html
@@ -70,7 +70,7 @@ Note: This API supports files up to 100 megabytes in size." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/releases_exist.html
+++ b/docs/reference/releases_exist.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/shas_exist.html
+++ b/docs/reference/shas_exist.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/source_files.html
+++ b/docs/reference/source_files.html
@@ -71,7 +71,7 @@ to 100 megabytes in size." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/tags_exist.html
+++ b/docs/reference/tags_exist.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/trees_exist.html
+++ b/docs/reference/trees_exist.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/update_branches.html
+++ b/docs/reference/update_branches.html
@@ -70,7 +70,7 @@ GitHub." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/update_card.html
+++ b/docs/reference/update_card.html
@@ -70,7 +70,7 @@ move_card() can be used to reorder the cards or move them to other columns." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/update_column.html
+++ b/docs/reference/update_column.html
@@ -70,7 +70,7 @@ move_column() can be used to reorder the columns." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/update_files.html
+++ b/docs/reference/update_files.html
@@ -71,7 +71,7 @@ committer and author can be set explicitly if necessary." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/update_organization.html
+++ b/docs/reference/update_organization.html
@@ -70,7 +70,7 @@ organization if you have the appropriate permissions." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/update_project.html
+++ b/docs/reference/update_project.html
@@ -37,7 +37,7 @@
 
 <meta property="og:title" content="Update a GitHub project — update_project" />
 <meta property="og:description" content="This function updates a project in GitHub. It can be used to change the name and body, but
-can also be used to close the project or change permissions." />
+can also be used to close the project, change permissions or add a team." />
 <meta name="twitter:card" content="summary" />
 
 
@@ -70,7 +70,7 @@ can also be used to close the project or change permissions." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 
@@ -116,7 +116,7 @@ can also be used to close the project or change permissions." />
 
     <div class="ref-description">
     <p>This function updates a project in GitHub. It can be used to change the name and body, but
-can also be used to close the project or change permissions.</p>
+can also be used to close the project, change permissions or add a team.</p>
     </div>
 
     <pre class="usage"><span class='fu'>update_project</span>(
@@ -128,6 +128,7 @@ can also be used to close the project or change permissions.</p>
   <span class='no'>private</span>,
   <span class='no'>repo</span>,
   <span class='no'>user</span>,
+  <span class='no'>team</span>,
   <span class='no'>org</span>,
   <span class='no'>...</span>
 )</pre>
@@ -153,12 +154,14 @@ can also be used to close the project or change permissions.</p>
     </tr>
     <tr>
       <th>permission</th>
-      <td><p>(string, optional) The new permissions for the project, either <code>"read"</code>,
-<code>"write"</code>, <code>"admin"</code> or <code>"none"</code>.</p></td>
+      <td><p>(string, optional) The new team or organisation permissions for the
+project, either <code>"read"</code>, <code>"write"</code>, <code>"admin"</code> or <code>"none"</code>. Note: applies to team and
+organization projects only.</p></td>
     </tr>
     <tr>
       <th>private</th>
-      <td><p>(boolean, optional) Whether the project should be private.</p></td>
+      <td><p>(boolean, optional) Whether the project should be private. Note: applies to
+team and organization projects only.</p></td>
     </tr>
     <tr>
       <th>repo</th>
@@ -167,6 +170,10 @@ can also be used to close the project or change permissions.</p>
     <tr>
       <th>user</th>
       <td><p>(string, optional) The login of the user.</p></td>
+    </tr>
+    <tr>
+      <th>team</th>
+      <td><p>(string or integer, optional) The team ID or name.</p></td>
     </tr>
     <tr>
       <th>org</th>
@@ -187,6 +194,10 @@ can also be used to close the project or change permissions.</p>
 <li><p><strong>name</strong>: The name given to the project.</p></li>
 <li><p><strong>body</strong>: The description given to the project.</p></li>
 <li><p><strong>state</strong>: Whether the project is "open" or "closed".</p></li>
+<li><p><strong>private</strong>: Whether the project is private (organization and team projects only).</p></li>
+<li><p><strong>org_permissions</strong>: The default permission for organization members (organization and
+team projects only).</p></li>
+<li><p><strong>team_permissions</strong>: The default permission for team members (team projects only).</p></li>
 <li><p><strong>creator</strong>: The user who created the project.</p></li>
 <li><p><strong>created_at</strong>: When it was created.</p></li>
 <li><p><strong>updated_at</strong>: When it was last updated.</p></li>
@@ -195,10 +206,13 @@ can also be used to close the project or change permissions.</p>
 
     <h2 class="hasAnchor" id="details"><a class="anchor" href="#details"></a>Details</h2>
 
-    <p>You can update a project associated with either a repository, user or organization, by
-supplying them as an input, as long as you have appropriate permissions.</p>
+    <p>You can update a project associated with either a repository, user, team or organization,
+by supplying them as an input, as long as you have appropriate permissions. Supplying a
+team that does not already have access to the project adds them. If they have access, then
+the team's permissions can be changed with the <code>permission</code> argument.</p>
 <p>For more details see the GitHub API documentation:</p><ul>
 <li><p><a href='https://developer.github.com/v3/projects/#update-a-project'>https://developer.github.com/v3/projects/#update-a-project</a></p></li>
+<li><p><a href='https://developer.github.com/v3/teams/#add-or-update-team-project'>https://developer.github.com/v3/teams/#add-or-update-team-project</a></p></li>
 </ul>
 
 
@@ -222,6 +236,19 @@ supplying them as an input, as long as you have appropriate permissions.</p>
     <span class='kw'>name</span>       <span class='kw'>=</span> <span class='st'>"Org project"</span>,
     <span class='kw'>permission</span> <span class='kw'>=</span> <span class='st'>"read"</span>,
     <span class='kw'>private</span>    <span class='kw'>=</span> <span class='fl'>TRUE</span>,
+    <span class='kw'>org</span>        <span class='kw'>=</span> <span class='st'>"HairyCoos"</span>)
+
+  <span class='co'># Add a team to the project</span>
+  <span class='fu'>update_project</span>(
+    <span class='kw'>project</span> <span class='kw'>=</span> <span class='st'>"Org project"</span>,
+    <span class='kw'>team</span>    <span class='kw'>=</span> <span class='st'>"HeadCoos"</span>,
+    <span class='kw'>org</span>     <span class='kw'>=</span> <span class='st'>"HairyCoos"</span>)
+
+  <span class='co'># Update the team's permissions on the project</span>
+  <span class='fu'>update_project</span>(
+    <span class='kw'>project</span>    <span class='kw'>=</span> <span class='st'>"Org project"</span>,
+    <span class='kw'>permission</span> <span class='kw'>=</span> <span class='st'>"write"</span>,
+    <span class='kw'>team</span>       <span class='kw'>=</span> <span class='st'>"HeadCoos"</span>,
     <span class='kw'>org</span>        <span class='kw'>=</span> <span class='st'>"HairyCoos"</span>)
 }</div></pre>
   </div>

--- a/docs/reference/update_releases.html
+++ b/docs/reference/update_releases.html
@@ -71,7 +71,7 @@ pre-releases." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/update_tags.html
+++ b/docs/reference/update_tags.html
@@ -70,7 +70,7 @@ GitHub." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/update_team.html
+++ b/docs/reference/update_team.html
@@ -70,7 +70,7 @@ the appropriate permissions." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/update_user.html
+++ b/docs/reference/update_user.html
@@ -70,7 +70,7 @@ profile." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/upload_blobs.html
+++ b/docs/reference/upload_blobs.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/upload_commit.html
+++ b/docs/reference/upload_commit.html
@@ -71,7 +71,7 @@ specified branch (using create_branches())." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/upload_tree.html
+++ b/docs/reference/upload_tree.html
@@ -71,7 +71,7 @@ uploaded as nested trees create_tree()." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/view_blobs.html
+++ b/docs/reference/view_blobs.html
@@ -70,7 +70,7 @@ GitHub." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/view_branches.html
+++ b/docs/reference/view_branches.html
@@ -71,7 +71,7 @@ are supplied then only information about those ones is returned." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/view_cards.html
+++ b/docs/reference/view_cards.html
@@ -71,7 +71,7 @@ for a single card." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 
@@ -187,7 +187,28 @@ or organization, by supplying them as an input.</p>
 
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
-    <pre class="examples"></pre>
+    <pre class="examples"><div class='input'><span class='kw'>if</span> (<span class='fl'>FALSE</span>) {
+  <span class='co'># View cards in a repository project</span>
+  <span class='no'>cards</span> <span class='kw'>&lt;-</span> <span class='fu'>view_cards</span>(
+    <span class='kw'>column</span>  <span class='kw'>=</span> <span class='st'>"Test cards"</span>,
+    <span class='kw'>project</span> <span class='kw'>=</span> <span class='st'>"Test cards"</span>,
+    <span class='kw'>repo</span>    <span class='kw'>=</span> <span class='st'>"ChadGoymer/test-githapi"</span>)
+
+  <span class='co'># View cards in a user's project</span>
+  <span class='no'>cards</span> <span class='kw'>&lt;-</span> <span class='fu'>view_cards</span>(
+    <span class='kw'>column</span>  <span class='kw'>=</span> <span class='st'>"Test cards"</span>,
+    <span class='kw'>project</span> <span class='kw'>=</span> <span class='st'>"Test cards"</span>,
+    <span class='kw'>user</span>    <span class='kw'>=</span> <span class='st'>"ChadGoymer"</span>)
+
+  <span class='co'># View cards in an organization's project</span>
+  <span class='no'>cards</span> <span class='kw'>&lt;-</span> <span class='fu'>view_cards</span>(
+    <span class='kw'>column</span>  <span class='kw'>=</span> <span class='st'>"Test cards"</span>,
+    <span class='kw'>project</span> <span class='kw'>=</span> <span class='st'>"Test cards"</span>,
+    <span class='kw'>org</span>     <span class='kw'>=</span> <span class='st'>"HairyCoos"</span>)
+
+  <span class='co'># View a single card</span>
+  <span class='fu'>view_card</span>(<span class='kw'>card</span> <span class='kw'>=</span> <span class='fl'>123456</span>)
+}</div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <h2>Contents</h2>

--- a/docs/reference/view_columns.html
+++ b/docs/reference/view_columns.html
@@ -71,7 +71,7 @@ single column." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/view_commits.html
+++ b/docs/reference/view_commits.html
@@ -69,7 +69,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/view_files.html
+++ b/docs/reference/view_files.html
@@ -72,7 +72,7 @@ is specified then details about all the files within the directory is returned."
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/view_history.html
+++ b/docs/reference/view_history.html
@@ -70,7 +70,7 @@ commit. The commit can be specified by a branch, tag or SHA." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/view_memberships.html
+++ b/docs/reference/view_memberships.html
@@ -71,7 +71,7 @@ of all membership properties for a single organization." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/view_organizations.html
+++ b/docs/reference/view_organizations.html
@@ -72,7 +72,7 @@ the default browser." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/view_projects.html
+++ b/docs/reference/view_projects.html
@@ -71,7 +71,7 @@ browse_project() opens the web page for the project in the default browser." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 
@@ -121,11 +121,11 @@ for each project. <code>view_project()</code> returns a list of all properties f
 <code>browse_project()</code> opens the web page for the project in the default browser.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>view_projects</span>(<span class='no'>repo</span>, <span class='no'>user</span>, <span class='no'>org</span>, <span class='kw'>state</span> <span class='kw'>=</span> <span class='st'>"open"</span>, <span class='kw'>n_max</span> <span class='kw'>=</span> <span class='fl'>1000</span>, <span class='no'>...</span>)
+    <pre class="usage"><span class='fu'>view_projects</span>(<span class='no'>repo</span>, <span class='no'>user</span>, <span class='no'>team</span>, <span class='no'>org</span>, <span class='kw'>state</span> <span class='kw'>=</span> <span class='st'>"open"</span>, <span class='kw'>n_max</span> <span class='kw'>=</span> <span class='fl'>1000</span>, <span class='no'>...</span>)
 
-<span class='fu'>view_project</span>(<span class='no'>project</span>, <span class='no'>repo</span>, <span class='no'>user</span>, <span class='no'>org</span>, <span class='no'>...</span>)
+<span class='fu'>view_project</span>(<span class='no'>project</span>, <span class='no'>repo</span>, <span class='no'>user</span>, <span class='no'>team</span>, <span class='no'>org</span>, <span class='no'>...</span>)
 
-<span class='fu'>browse_project</span>(<span class='no'>project</span>, <span class='no'>repo</span>, <span class='no'>user</span>, <span class='no'>org</span>, <span class='no'>...</span>)</pre>
+<span class='fu'>browse_project</span>(<span class='no'>project</span>, <span class='no'>repo</span>, <span class='no'>user</span>, <span class='no'>team</span>, <span class='no'>org</span>, <span class='no'>...</span>)</pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -137,6 +137,10 @@ for each project. <code>view_project()</code> returns a list of all properties f
     <tr>
       <th>user</th>
       <td><p>(string, optional) The login of the user.</p></td>
+    </tr>
+    <tr>
+      <th>team</th>
+      <td><p>(string or integer, optional) The team ID or name.</p></td>
     </tr>
     <tr>
       <th>org</th>
@@ -172,6 +176,10 @@ browser on the project's page and returns the URL invisibly.</p>
 <li><p><strong>name</strong>: The name given to the project.</p></li>
 <li><p><strong>body</strong>: The description given to the project.</p></li>
 <li><p><strong>state</strong>: Whether the project is "open" or "closed".</p></li>
+<li><p><strong>private</strong>: Whether the project is private (organization and team projects only).</p></li>
+<li><p><strong>org_permissions</strong>: The default permission for organization members (organization and
+team projects only).</p></li>
+<li><p><strong>team_permissions</strong>: The default permission for team members (team projects only).</p></li>
 <li><p><strong>creator</strong>: The user who created the project.</p></li>
 <li><p><strong>created_at</strong>: When it was created.</p></li>
 <li><p><strong>updated_at</strong>: When it was last updated.</p></li>
@@ -180,12 +188,13 @@ browser on the project's page and returns the URL invisibly.</p>
 
     <h2 class="hasAnchor" id="details"><a class="anchor" href="#details"></a>Details</h2>
 
-    <p>You can summarise all the projects associated with either a repository, user or
+    <p>You can summarise all the projects associated with either a repository, user, team or
 organization, by supplying them as an input.</p>
 <p>For more details see the GitHub API documentation:</p><ul>
 <li><p><a href='https://developer.github.com/v3/projects/#list-repository-projects'>https://developer.github.com/v3/projects/#list-repository-projects</a></p></li>
 <li><p><a href='https://developer.github.com/v3/projects/#list-user-projects'>https://developer.github.com/v3/projects/#list-user-projects</a></p></li>
 <li><p><a href='https://developer.github.com/v3/projects/#list-organization-projects'>https://developer.github.com/v3/projects/#list-organization-projects</a></p></li>
+<li><p><a href='https://developer.github.com/v3/teams/#review-a-team-project'>https://developer.github.com/v3/teams/#review-a-team-project</a></p></li>
 <li><p><a href='https://developer.github.com/v3/projects/#get-a-project'>https://developer.github.com/v3/projects/#get-a-project</a></p></li>
 </ul>
 
@@ -200,6 +209,9 @@ organization, by supplying them as an input.</p>
 
   <span class='co'># View an organization's projects</span>
   <span class='fu'>view_projects</span>(<span class='kw'>org</span> <span class='kw'>=</span> <span class='st'>"HairyCoos"</span>)
+
+  <span class='co'># View a team's projects</span>
+  <span class='fu'>view_projects</span>(<span class='kw'>team</span> <span class='kw'>=</span> <span class='st'>"HeadCoos"</span>, <span class='kw'>org</span> <span class='kw'>=</span> <span class='st'>"HairyCoos"</span>)
 
   <span class='co'># View closed projects</span>
   <span class='fu'>view_projects</span>(<span class='st'>"ChadGoymer/githapi"</span>, <span class='kw'>state</span> <span class='kw'>=</span> <span class='st'>"closed"</span>)
@@ -216,6 +228,9 @@ organization, by supplying them as an input.</p>
   <span class='co'># View a specific organization project</span>
   <span class='fu'>view_project</span>(<span class='st'>"Prioritisation"</span>, <span class='kw'>org</span> <span class='kw'>=</span> <span class='st'>"HairyCoos"</span>)
 
+  <span class='co'># View a specific team project</span>
+  <span class='fu'>view_project</span>(<span class='st'>"Prioritisation"</span>, <span class='kw'>team</span> <span class='kw'>=</span> <span class='st'>"HeadCoos"</span>, <span class='kw'>org</span> <span class='kw'>=</span> <span class='st'>"HairyCoos"</span>)
+
   <span class='co'># Browse a specific repository project</span>
   <span class='fu'>browse_project</span>(<span class='st'>"Prioritisation"</span>, <span class='st'>"ChadGoymer/githapi"</span>)
 
@@ -224,6 +239,9 @@ organization, by supplying them as an input.</p>
 
   <span class='co'># Browse a specific organization project</span>
   <span class='fu'>browse_project</span>(<span class='st'>"Prioritisation"</span>, <span class='kw'>org</span> <span class='kw'>=</span> <span class='st'>"HairyCoos"</span>)
+
+  <span class='co'># Browse a specific team project</span>
+  <span class='fu'>browse_project</span>(<span class='st'>"Prioritisation"</span>, <span class='kw'>team</span> <span class='kw'>=</span> <span class='st'>"HeadCoos"</span>, <span class='kw'>org</span> <span class='kw'>=</span> <span class='st'>"HairyCoos"</span>)
 }</div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">

--- a/docs/reference/view_releases.html
+++ b/docs/reference/view_releases.html
@@ -72,7 +72,7 @@ of a tag the latest non-draft, non-prerelease release is returned." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/view_shas.html
+++ b/docs/reference/view_shas.html
@@ -71,7 +71,7 @@ same SHA). If a branch is specified the function returns the SHA of the head com
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/view_tags.html
+++ b/docs/reference/view_tags.html
@@ -71,7 +71,7 @@ information about those ones is returned." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/view_teams.html
+++ b/docs/reference/view_teams.html
@@ -71,7 +71,7 @@ opens the web page for the team in the default browser." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/view_trees.html
+++ b/docs/reference/view_trees.html
@@ -70,7 +70,7 @@ GitHub. A tree describes the the blobs, or files, usually in a commit." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/docs/reference/view_users.html
+++ b/docs/reference/view_users.html
@@ -71,7 +71,7 @@ browse_user() opens the web page for the user in the default browser." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">githapi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.9</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.9.10</span>
       </span>
     </div>
 

--- a/man/create_project.Rd
+++ b/man/create_project.Rd
@@ -27,6 +27,9 @@ create_project(name, body, repo, org, ...)
 \item \strong{name}: The name given to the project.
 \item \strong{body}: The description given to the project.
 \item \strong{state}: Whether the project is "open" or "closed".
+\item \strong{private}: Whether the project is private (organisation project only).
+\item \strong{org_permission}: The default permission for the project - either "read", "write" or
+"admin" (organisation project only).
 \item \strong{creator}: The user who created the project.
 \item \strong{created_at}: When it was created.
 \item \strong{updated_at}: When it was last updated.
@@ -64,8 +67,8 @@ For more details see the GitHub API documentation:
 
   # Create a project for an organization
   create_project(
-    name = "Repo project",
-    body = "This is a repository's project",
+    name = "Organization project",
+    body = "This is an organization's project",
     org  = "HairyCoos")
 }
 

--- a/man/delete_project.Rd
+++ b/man/delete_project.Rd
@@ -4,7 +4,7 @@
 \alias{delete_project}
 \title{Delete a GitHub project}
 \usage{
-delete_project(project, repo, user, org, ...)
+delete_project(project, repo, user, team, org, ...)
 }
 \arguments{
 \item{project}{(integer or string) Either the project number or name.}
@@ -12,6 +12,8 @@ delete_project(project, repo, user, org, ...)
 \item{repo}{(string, optional) The repository specified in the format: \code{owner/repo}.}
 
 \item{user}{(string, optional) The login of the user.}
+
+\item{team}{(string or integer, optional) The team ID or name.}
 
 \item{org}{(string, optional) The name of the organization.}
 
@@ -25,12 +27,15 @@ This function deletes a project in GitHub. Care should be taken as it will not b
 recoverable. If you just want to close the project use \code{\link[=update_project]{update_project()}}.
 }
 \details{
-You can delete a project associated with either a repository, user or organization, by
-supplying them as an input, as long as you have appropriate permissions.
+You can delete a project associated with either a repository, user, team or organization,
+by supplying them as an input, as long as you have appropriate permissions. Deleting a
+team project just removes the team's access. If you want to delete it completely you
+have to delete the organization's project.
 
 For more details see the GitHub API documentation:
 \itemize{
 \item \url{https://developer.github.com/v3/projects/#delete-a-project}
+\item \url{https://developer.github.com/v3/teams/#remove-team-project}
 }
 }
 \examples{
@@ -44,6 +49,12 @@ For more details see the GitHub API documentation:
   delete_project(
     project = "User project",
     user    = "ChadGoymer")
+
+  # Remove a team's access to the organization's project
+  delete_project(
+    project = "User project",
+    team    = "HeadCoos",
+    org     = "HairyCoos")
 
   # Delete a project for an organization
   delete_project(

--- a/man/update_project.Rd
+++ b/man/update_project.Rd
@@ -13,6 +13,7 @@ update_project(
   private,
   repo,
   user,
+  team,
   org,
   ...
 )
@@ -26,14 +27,18 @@ update_project(
 
 \item{state}{(string, optional) The new state of the project, either \code{"open"} or \code{"closed"}.}
 
-\item{permission}{(string, optional) The new permissions for the project, either \code{"read"},
-\code{"write"}, \code{"admin"} or \code{"none"}.}
+\item{permission}{(string, optional) The new team or organisation permissions for the
+project, either \code{"read"}, \code{"write"}, \code{"admin"} or \code{"none"}. Note: applies to team and
+organization projects only.}
 
-\item{private}{(boolean, optional) Whether the project should be private.}
+\item{private}{(boolean, optional) Whether the project should be private. Note: applies to
+team and organization projects only.}
 
 \item{repo}{(string, optional) The repository specified in the format: \code{owner/repo}.}
 
 \item{user}{(string, optional) The login of the user.}
+
+\item{team}{(string or integer, optional) The team ID or name.}
 
 \item{org}{(string, optional) The name of the organization.}
 
@@ -49,6 +54,10 @@ update_project(
 \item \strong{name}: The name given to the project.
 \item \strong{body}: The description given to the project.
 \item \strong{state}: Whether the project is "open" or "closed".
+\item \strong{private}: Whether the project is private (organization and team projects only).
+\item \strong{org_permissions}: The default permission for organization members (organization and
+team projects only).
+\item \strong{team_permissions}: The default permission for team members (team projects only).
 \item \strong{creator}: The user who created the project.
 \item \strong{created_at}: When it was created.
 \item \strong{updated_at}: When it was last updated.
@@ -57,15 +66,18 @@ update_project(
 }
 \description{
 This function updates a project in GitHub. It can be used to change the name and body, but
-can also be used to close the project or change permissions.
+can also be used to close the project, change permissions or add a team.
 }
 \details{
-You can update a project associated with either a repository, user or organization, by
-supplying them as an input, as long as you have appropriate permissions.
+You can update a project associated with either a repository, user, team or organization,
+by supplying them as an input, as long as you have appropriate permissions. Supplying a
+team that does not already have access to the project adds them. If they have access, then
+the team's permissions can be changed with the \code{permission} argument.
 
 For more details see the GitHub API documentation:
 \itemize{
 \item \url{https://developer.github.com/v3/projects/#update-a-project}
+\item \url{https://developer.github.com/v3/teams/#add-or-update-team-project}
 }
 }
 \examples{
@@ -88,6 +100,19 @@ For more details see the GitHub API documentation:
     name       = "Org project",
     permission = "read",
     private    = TRUE,
+    org        = "HairyCoos")
+
+  # Add a team to the project
+  update_project(
+    project = "Org project",
+    team    = "HeadCoos",
+    org     = "HairyCoos")
+
+  # Update the team's permissions on the project
+  update_project(
+    project    = "Org project",
+    permission = "write",
+    team       = "HeadCoos",
     org        = "HairyCoos")
 }
 

--- a/man/view_cards.Rd
+++ b/man/view_cards.Rd
@@ -71,7 +71,6 @@ For more details see the GitHub API documentation:
     user    = "ChadGoymer")
 
   # View cards in an organization's project
-  view_card(
   cards <- view_cards(
     column  = "Test cards",
     project = "Test cards",

--- a/man/view_projects.Rd
+++ b/man/view_projects.Rd
@@ -6,16 +6,18 @@
 \alias{browse_project}
 \title{View GitHub projects}
 \usage{
-view_projects(repo, user, org, state = "open", n_max = 1000, ...)
+view_projects(repo, user, team, org, state = "open", n_max = 1000, ...)
 
-view_project(project, repo, user, org, ...)
+view_project(project, repo, user, team, org, ...)
 
-browse_project(project, repo, user, org, ...)
+browse_project(project, repo, user, team, org, ...)
 }
 \arguments{
 \item{repo}{(string, optional) The repository specified in the format: \code{owner/repo}.}
 
 \item{user}{(string, optional) The login of the user.}
+
+\item{team}{(string or integer, optional) The team ID or name.}
 
 \item{org}{(string, optional) The name of the organization.}
 
@@ -40,6 +42,10 @@ browser on the project's page and returns the URL invisibly.
 \item \strong{name}: The name given to the project.
 \item \strong{body}: The description given to the project.
 \item \strong{state}: Whether the project is "open" or "closed".
+\item \strong{private}: Whether the project is private (organization and team projects only).
+\item \strong{org_permissions}: The default permission for organization members (organization and
+team projects only).
+\item \strong{team_permissions}: The default permission for team members (team projects only).
 \item \strong{creator}: The user who created the project.
 \item \strong{created_at}: When it was created.
 \item \strong{updated_at}: When it was last updated.
@@ -52,7 +58,7 @@ for each project. \code{view_project()} returns a list of all properties for a s
 \code{browse_project()} opens the web page for the project in the default browser.
 }
 \details{
-You can summarise all the projects associated with either a repository, user or
+You can summarise all the projects associated with either a repository, user, team or
 organization, by supplying them as an input.
 
 For more details see the GitHub API documentation:
@@ -60,6 +66,7 @@ For more details see the GitHub API documentation:
 \item \url{https://developer.github.com/v3/projects/#list-repository-projects}
 \item \url{https://developer.github.com/v3/projects/#list-user-projects}
 \item \url{https://developer.github.com/v3/projects/#list-organization-projects}
+\item \url{https://developer.github.com/v3/teams/#review-a-team-project}
 \item \url{https://developer.github.com/v3/projects/#get-a-project}
 }
 }
@@ -73,6 +80,9 @@ For more details see the GitHub API documentation:
 
   # View an organization's projects
   view_projects(org = "HairyCoos")
+
+  # View a team's projects
+  view_projects(team = "HeadCoos", org = "HairyCoos")
 
   # View closed projects
   view_projects("ChadGoymer/githapi", state = "closed")
@@ -89,6 +99,9 @@ For more details see the GitHub API documentation:
   # View a specific organization project
   view_project("Prioritisation", org = "HairyCoos")
 
+  # View a specific team project
+  view_project("Prioritisation", team = "HeadCoos", org = "HairyCoos")
+
   # Browse a specific repository project
   browse_project("Prioritisation", "ChadGoymer/githapi")
 
@@ -97,6 +110,9 @@ For more details see the GitHub API documentation:
 
   # Browse a specific organization project
   browse_project("Prioritisation", org = "HairyCoos")
+
+  # Browse a specific team project
+  browse_project("Prioritisation", team = "HeadCoos", org = "HairyCoos")
 }
 
 }

--- a/tests/testthat/test-cards.R
+++ b/tests/testthat/test-cards.R
@@ -1,34 +1,38 @@
 context("cards api")
 
 
-setup(suppressMessages({
+# SETUP ---------------------------------------------------------------------------------------
+
+now <- format(Sys.time(), "%Y%m%d-%H%M%S")
+
+setup(suppressMessages(try(silent = TRUE, {
 
   test_project <- create_project(
-    name = "Test cards",
+    name = paste("Test cards", now),
     body = "A project to test card functions",
     repo = "ChadGoymer/test-githapi")
 
   test_column <- create_column(
-    name    = "Test cards",
-    project = "Test cards",
+    name    = paste("Test cards", now),
+    project = paste("Test cards", now),
     repo    = "ChadGoymer/test-githapi")
 
-}))
+})))
 
-teardown(suppressMessages(tryCatch({
+teardown(suppressMessages(try(silent = TRUE, {
 
   delete_column(
-    column  = "Test cards",
-    project = "Test cards",
+    column  = paste("Test cards", now),
+    project = paste("Test cards", now),
     repo    = "ChadGoymer/test-githapi")
 
   delete_column(
-    column  = "Test cards 2",
-    project = "Test cards",
+    column  = paste("Test cards 2", now),
+    project = paste("Test cards", now),
     repo    = "ChadGoymer/test-githapi")
 
   delete_project(
-    project = "Test cards",
+    project = paste("Test cards", now),
     repo    = "ChadGoymer/test-githapi")
 
 })))
@@ -41,8 +45,8 @@ test_that("create_cards creates a card and returns its properties", {
   issue_card <- create_card(
     content_id   = 1,
     content_type = "Issue",
-    column       = "Test cards",
-    project      = "Test cards",
+    column       = paste("Test cards", now),
+    project      = paste("Test cards", now),
     repo         = "ChadGoymer/test-githapi")
 
   expect_is(issue_card, "list")
@@ -62,8 +66,8 @@ test_that("create_cards creates a card and returns its properties", {
   pull_card <- create_card(
     content_id   = 2,
     content_type = "PullRequest",
-    column       = "Test cards",
-    project      = "Test cards",
+    column       = paste("Test cards", now),
+    project      = paste("Test cards", now),
     repo         = "ChadGoymer/test-githapi")
 
   expect_is(pull_card, "list")
@@ -82,8 +86,8 @@ test_that("create_cards creates a card and returns its properties", {
 
   note_card <- create_card(
     note    = "Note Title\nThis is a note",
-    column  = "Test cards",
-    project = "Test cards",
+    column  = paste("Test cards", now),
+    project = paste("Test cards", now),
     repo    = "ChadGoymer/test-githapi")
 
   expect_is(note_card, "list")
@@ -106,8 +110,8 @@ test_that("create_card throws an error in invalid arguments are supplied", {
 
   expect_error(
     create_card(
-      column  = "Test cards",
-      project = "Test cards",
+      column  = paste("Test cards", now),
+      project = paste("Test cards", now),
       repo    = "ChadGoymer/test-githapi"),
     "Either 'content_id' or 'note' must be supplied")
 
@@ -118,8 +122,8 @@ test_that("create_card throws an error in invalid arguments are supplied", {
 
 suppressMessages({
   cards <- view_cards(
-    column  = "Test cards",
-    project = "Test cards",
+    column  = paste("Test cards", now),
+    project = paste("Test cards", now),
     repo    = "ChadGoymer/test-githapi")
 })
 
@@ -231,15 +235,15 @@ test_that("move_card changes the position of a card", {
 test_that("move_card changes the column a card is in", {
 
   column2 <- create_column(
-    name    = "Test cards 2",
-    project = "Test cards",
+    name    = paste("Test cards 2", now),
+    project = paste("Test cards", now),
     repo    = "ChadGoymer/test-githapi")
 
   column_card <- move_card(
     card     = issue_card_id,
     position = "top",
-    column   = "Test cards 2",
-    project  = "Test cards",
+    column   = paste("Test cards 2", now),
+    project  = paste("Test cards", now),
     repo     = "ChadGoymer/test-githapi")
 
   expect_is(column_card, "list")
@@ -270,8 +274,8 @@ test_that("move_card throws an error in invalid arguments are supplied", {
 test_that("view_cards returns a tibble summarising the cards", {
 
   cards <- view_cards(
-    column  = "Test cards",
-    project = "Test cards",
+    column  = paste("Test cards", now),
+    project = paste("Test cards", now),
     repo    = "ChadGoymer/test-githapi")
 
   expect_is(cards, "tbl")

--- a/tests/testthat/test-columns.R
+++ b/tests/testthat/test-columns.R
@@ -1,19 +1,23 @@
 context("columns api")
 
 
-setup(suppressMessages({
+# SETUP ---------------------------------------------------------------------------------------
+
+now <- format(Sys.time(), "%Y%m%d-%H%M%S")
+
+setup(suppressMessages(try(silent = TRUE, {
 
   test_project <- create_project(
-    name = "Test columns",
+    name = paste("Test columns", now),
     body = "A project to test columns functions",
     repo = "ChadGoymer/test-githapi")
 
-}))
+})))
 
-teardown(suppressMessages(tryCatch({
+teardown(suppressMessages(try(silent = TRUE, {
 
   delete_project(
-    project = "Test columns",
+    project = paste("Test columns", now),
     repo    = "ChadGoymer/test-githapi")
 
 })))
@@ -24,8 +28,8 @@ teardown(suppressMessages(tryCatch({
 test_that("create_columns creates a column and returns its properties", {
 
   column <- create_column(
-    name    = "Test column",
-    project = "Test columns",
+    name    = paste("Test column", now),
+    project = paste("Test columns", now),
     repo    = "ChadGoymer/test-githapi")
 
   expect_is(column, "list")
@@ -37,7 +41,7 @@ test_that("create_columns creates a column and returns its properties", {
       created_at = "POSIXct",
       updated_at = "POSIXct"))
 
-  expect_identical(column$name, "Test column")
+  expect_identical(column$name, paste("Test column", now))
 
 })
 
@@ -47,9 +51,9 @@ test_that("create_columns creates a column and returns its properties", {
 test_that("update_column updates a column and returns a list of the new properties", {
 
   column <- update_column(
-    column  = "Test column",
-    name    = "Updated test column",
-    project = "Test columns",
+    column  = paste("Test column", now),
+    name    = paste("Updated test column", now),
+    project = paste("Test columns", now),
     repo    = "ChadGoymer/test-githapi")
 
   expect_is(column, "list")
@@ -61,7 +65,7 @@ test_that("update_column updates a column and returns a list of the new properti
       created_at = "POSIXct",
       updated_at = "POSIXct"))
 
-  expect_identical(column$name, "Updated test column")
+  expect_identical(column$name, paste("Updated test column", now))
 
 })
 
@@ -71,14 +75,14 @@ test_that("update_column updates a column and returns a list of the new properti
 test_that("move_column changes the position of a column", {
 
   column2 <- create_column(
-    name    = "Test column 2",
-    project = "Test columns",
+    name    = paste("Test column 2", now),
+    project = paste("Test columns", now),
     repo    = "ChadGoymer/test-githapi")
 
   first_column <- move_column(
-    column   = "Test column 2",
+    column   = paste("Test column 2", now),
     position = "first",
-    project  = "Test columns",
+    project  = paste("Test columns", now),
     repo     = "ChadGoymer/test-githapi")
 
   expect_is(first_column, "list")
@@ -91,9 +95,9 @@ test_that("move_column changes the position of a column", {
       updated_at = "POSIXct"))
 
   last_column <- move_column(
-    column   = "Test column 2",
+    column   = paste("Test column 2", now),
     position = "last",
-    project  = "Test columns",
+    project  = paste("Test columns", now),
     repo     = "ChadGoymer/test-githapi")
 
   expect_is(last_column, "list")
@@ -106,9 +110,9 @@ test_that("move_column changes the position of a column", {
       updated_at = "POSIXct"))
 
   after_column <- move_column(
-    column  = "Updated test column",
-    after   = "Test column 2",
-    project = "Test columns",
+    column  = paste("Updated test column", now),
+    after   = paste("Test column 2", now),
+    project = paste("Test columns", now),
     repo    = "ChadGoymer/test-githapi")
 
   expect_is(after_column, "list")
@@ -125,7 +129,10 @@ test_that("move_column changes the position of a column", {
 test_that("move_column throws an error in invalid arguments are supplied", {
 
   expect_error(
-    move_column("Test column 2", project = "Test columns", repo = "ChadGoymer/test-githapi"),
+    move_column(
+      column  = paste("Test column 2", now),
+      project = paste("Test columns", now),
+      repo    = "ChadGoymer/test-githapi"),
     "Either 'position' or 'after' must be supplied")
 
 })
@@ -135,7 +142,7 @@ test_that("move_column throws an error in invalid arguments are supplied", {
 
 test_that("view_columns returns a tibble summarising the columns", {
 
-  columns <- view_columns("Test columns", "ChadGoymer/test-githapi")
+  columns <- view_columns(paste("Test columns", now), "ChadGoymer/test-githapi")
 
   expect_is(columns, "tbl")
   expect_identical(attr(columns, "status"), 200L)
@@ -146,7 +153,7 @@ test_that("view_columns returns a tibble summarising the columns", {
       created_at = "POSIXct",
       updated_at = "POSIXct"))
 
-  expect_true("Updated test column" %in% columns$name)
+  expect_true(paste("Updated test column", now) %in% columns$name)
 
 })
 
@@ -156,8 +163,8 @@ test_that("view_columns returns a tibble summarising the columns", {
 test_that("view_column returns a list of column properties", {
 
   column <- view_column(
-    column  = "Updated test column",
-    project = "Test columns",
+    column  = paste("Updated test column", now),
+    project = paste("Test columns", now),
     repo    = "ChadGoymer/test-githapi")
 
   expect_is(column, "list")
@@ -169,7 +176,7 @@ test_that("view_column returns a list of column properties", {
       created_at = "POSIXct",
       updated_at = "POSIXct"))
 
-  expect_identical(column$name, "Updated test column")
+  expect_identical(column$name, paste("Updated test column", now))
 
   column_by_id <- view_column(column = column$id)
 
@@ -188,11 +195,11 @@ test_that("view_column returns a list of column properties", {
 
 test_that("view_column can accept a column number", {
 
-  columns <- view_columns("Test columns", "ChadGoymer/test-githapi")
+  columns <- view_columns(paste("Test columns", now), "ChadGoymer/test-githapi")
 
   first_column <- view_column(
     columns$id[[1]],
-    project = "Test columns",
+    project = paste("Test columns", now),
     repo    = "ChadGoymer/test-githapi")
 
   expect_is(first_column, "list")
@@ -211,7 +218,7 @@ test_that("view_column can accept a column number", {
 test_that("view_column throws an error if invalid arguments are supplied", {
 
   expect_error(
-    view_column(TRUE, "Test columns", "ChadGoymer/test-githapi"),
+    view_column(TRUE, paste("Test columns", now), "ChadGoymer/test-githapi"),
     "'column' must be either an integer or a string")
 
 })
@@ -222,8 +229,8 @@ test_that("view_column throws an error if invalid arguments are supplied", {
 test_that("delete_column deletes the columns and returns TRUE", {
 
   column <- delete_column(
-    column  = "Updated test column",
-    project = "Test columns",
+    column  = paste("Updated test column", now),
+    project = paste("Test columns", now),
     repo    = "ChadGoymer/test-githapi")
 
   expect_is(column, "logical")

--- a/tests/testthat/test-github-api.R
+++ b/tests/testthat/test-github-api.R
@@ -278,7 +278,7 @@ test_that("gh_find throws an error if it cannot find the specified property valu
       url      = "https://api.github.com/repos/ChadGoymer/test-githapi/git/refs/heads",
       property = "ref",
       value    = "refs/heads/bob"),
-    "Could not find an entity with the specified value, 'refs/heads/bob', for the specified property 'ref'")
+    "Could not find an entity with 'ref' equal to 'refs/heads/bob'")
 
 })
 

--- a/tests/testthat/test-projects.R
+++ b/tests/testthat/test-projects.R
@@ -19,8 +19,6 @@ test_that("create_projects creates a project and returns its properties", {
       name       = "character",
       body       = "character",
       state      = "character",
-      permission = "character",
-      private    = "logical",
       creator    = "character",
       created_at = "POSIXct",
       updated_at = "POSIXct",
@@ -41,8 +39,6 @@ test_that("create_projects creates a project and returns its properties", {
       name       = "character",
       body       = "character",
       state      = "character",
-      permission = "character",
-      private    = "logical",
       creator    = "character",
       created_at = "POSIXct",
       updated_at = "POSIXct",
@@ -59,17 +55,17 @@ test_that("create_projects creates a project and returns its properties", {
   expect_identical(attr(org_project, "status"), 201L)
   expect_identical(
     map_chr(org_project, ~ class(.)[[1]]),
-    c(id         = "integer",
-      number     = "integer",
-      name       = "character",
-      body       = "character",
-      state      = "character",
-      permission = "character",
-      private    = "logical",
-      creator    = "character",
-      created_at = "POSIXct",
-      updated_at = "POSIXct",
-      html_url   = "character"))
+    c(id             = "integer",
+      number         = "integer",
+      name           = "character",
+      body           = "character",
+      state          = "character",
+      private        = "logical",
+      org_permission = "character",
+      creator        = "character",
+      created_at     = "POSIXct",
+      updated_at     = "POSIXct",
+      html_url       = "character"))
 
   expect_identical(org_project$name, "Organization project")
 

--- a/tests/testthat/test-projects.R
+++ b/tests/testthat/test-projects.R
@@ -496,6 +496,15 @@ test_that("delete_project deletes the projects and returns TRUE", {
   expect_identical(attr(user_project, "status"), 204L)
   expect_identical(as.logical(user_project), TRUE)
 
+  team_project <- delete_project(
+    project = "Organization project",
+    team    = "TestProjectsTeam",
+    org     = "HairyCoos")
+
+  expect_is(team_project, "logical")
+  expect_identical(attr(team_project, "status"), 204L)
+  expect_identical(as.logical(team_project), TRUE)
+
   org_project <- delete_project("Organization project", org = "HairyCoos")
 
   expect_is(org_project, "logical")

--- a/tests/testthat/test-projects.R
+++ b/tests/testthat/test-projects.R
@@ -243,8 +243,6 @@ test_that("view_projects returns a tibble summarising the projects", {
       name       = "character",
       body       = "character",
       state      = "character",
-      permission = "character",
-      private    = "logical",
       creator    = "character",
       created_at = "POSIXct",
       updated_at = "POSIXct",
@@ -263,8 +261,6 @@ test_that("view_projects returns a tibble summarising the projects", {
       name       = "character",
       body       = "character",
       state      = "character",
-      permission = "character",
-      private    = "logical",
       creator    = "character",
       created_at = "POSIXct",
       updated_at = "POSIXct",
@@ -278,19 +274,40 @@ test_that("view_projects returns a tibble summarising the projects", {
   expect_identical(attr(org_projects, "status"), 200L)
   expect_identical(
     map_chr(org_projects, ~ class(.)[[1]]),
-    c(id         = "integer",
-      number     = "integer",
-      name       = "character",
-      body       = "character",
-      state      = "character",
-      permission = "character",
-      private    = "logical",
-      creator    = "character",
-      created_at = "POSIXct",
-      updated_at = "POSIXct",
-      html_url   = "character"))
+    c(id             = "integer",
+      number         = "integer",
+      name           = "character",
+      body           = "character",
+      state          = "character",
+      private        = "logical",
+      org_permission = "character",
+      creator        = "character",
+      created_at     = "POSIXct",
+      updated_at     = "POSIXct",
+      html_url       = "character"))
 
   expect_true("Organization project" %in% org_projects$name)
+
+  team_projects <- view_projects(team = "TestProjectsTeam", org = "HairyCoos")
+
+  expect_is(team_projects, "tbl")
+  expect_identical(attr(team_projects, "status"), 200L)
+  expect_identical(
+    map_chr(team_projects, ~ class(.)[[1]]),
+    c(id              = "integer",
+      number          = "integer",
+      name            = "character",
+      body            = "character",
+      state           = "character",
+      private         = "logical",
+      org_permission  = "character",
+      team_permission = "character",
+      creator         = "character",
+      created_at      = "POSIXct",
+      updated_at      = "POSIXct",
+      html_url        = "character"))
+
+  expect_true("Organization project" %in% team_projects$name)
 
 })
 

--- a/tests/testthat/test-projects.R
+++ b/tests/testthat/test-projects.R
@@ -468,6 +468,15 @@ test_that("browse_project opens the project in the browser", {
   expect_identical(attr(org_project, "status"), 200L)
   expect_identical(dirname(org_project), "https://github.com/orgs/HairyCoos/projects")
 
+  team_project <- browse_project(
+    project = "Organization project",
+    team    = "TestProjectsTeam",
+    org     = "HairyCoos")
+
+  expect_is(team_project, "character")
+  expect_identical(attr(team_project, "status"), 200L)
+  expect_identical(dirname(team_project), "https://github.com/orgs/HairyCoos/projects")
+
 })
 
 

--- a/tests/testthat/test-projects.R
+++ b/tests/testthat/test-projects.R
@@ -1,6 +1,18 @@
 context("projects api")
 
 
+setup(try(silent = TRUE, {
+  test_team <- create_team(
+    name        = "TestProjectsTeam",
+    description = "This was created to test team projects",
+    org         = "HairyCoos")
+}))
+
+teardown(try(silent = TRUE, {
+  delete_team("TestProjectsTeam", org = "HairyCoos")
+}))
+
+
 # TEST: create_project ------------------------------------------------------------------------
 
 test_that("create_projects creates a project and returns its properties", {
@@ -111,8 +123,6 @@ test_that("update_project updates a project and returns a list of the new proper
       name       = "character",
       body       = "character",
       state      = "character",
-      permission = "character",
-      private    = "logical",
       creator    = "character",
       created_at = "POSIXct",
       updated_at = "POSIXct",
@@ -134,8 +144,6 @@ test_that("update_project updates a project and returns a list of the new proper
       name       = "character",
       body       = "character",
       state      = "character",
-      permission = "character",
-      private    = "logical",
       creator    = "character",
       created_at = "POSIXct",
       updated_at = "POSIXct",
@@ -153,20 +161,69 @@ test_that("update_project updates a project and returns a list of the new proper
   expect_identical(attr(org_project, "status"), 200L)
   expect_identical(
     map_chr(org_project, ~ class(.)[[1]]),
-    c(id         = "integer",
-      number     = "integer",
-      name       = "character",
-      body       = "character",
-      state      = "character",
-      permission = "character",
-      private    = "logical",
-      creator    = "character",
-      created_at = "POSIXct",
-      updated_at = "POSIXct",
-      html_url   = "character"))
+    c(id             = "integer",
+      number         = "integer",
+      name           = "character",
+      body           = "character",
+      state          = "character",
+      private        = "logical",
+      org_permission = "character",
+      creator        = "character",
+      created_at     = "POSIXct",
+      updated_at     = "POSIXct",
+      html_url       = "character"))
 
-  expect_identical(org_project$permission, "read")
+  expect_identical(org_project$org_permission, "read")
   expect_identical(org_project$private, FALSE)
+
+  team_project <- update_project(
+    project = "Organization project",
+    team    = "TestProjectsTeam",
+    org     = "HairyCoos")
+
+  expect_is(team_project, "list")
+  expect_identical(attr(team_project, "status"), 204L)
+  expect_identical(
+    map_chr(team_project, ~ class(.)[[1]]),
+    c(id              = "integer",
+      number          = "integer",
+      name            = "character",
+      body            = "character",
+      state           = "character",
+      private         = "logical",
+      org_permission  = "character",
+      team_permission = "character",
+      creator         = "character",
+      created_at      = "POSIXct",
+      updated_at      = "POSIXct",
+      html_url        = "character"))
+
+  expect_identical(team_project$team_permission, "write")
+
+  upd_team_project <- update_project(
+    project    = "Organization project",
+    team       = "TestProjectsTeam",
+    org        = "HairyCoos",
+    permission = "read")
+
+  expect_is(upd_team_project, "list")
+  expect_identical(attr(upd_team_project, "status"), 204L)
+  expect_identical(
+    map_chr(upd_team_project, ~ class(.)[[1]]),
+    c(id              = "integer",
+      number          = "integer",
+      name            = "character",
+      body            = "character",
+      state           = "character",
+      private         = "logical",
+      org_permission  = "character",
+      team_permission = "character",
+      creator         = "character",
+      created_at      = "POSIXct",
+      updated_at      = "POSIXct",
+      html_url        = "character"))
+
+  expect_identical(upd_team_project$team_permission, "read")
 
 })
 

--- a/tests/testthat/test-projects.R
+++ b/tests/testthat/test-projects.R
@@ -335,8 +335,6 @@ test_that("view_project returns a list of project properties", {
       name       = "character",
       body       = "character",
       state      = "character",
-      permission = "character",
-      private    = "logical",
       creator    = "character",
       created_at = "POSIXct",
       updated_at = "POSIXct",
@@ -355,8 +353,6 @@ test_that("view_project returns a list of project properties", {
       name       = "character",
       body       = "character",
       state      = "character",
-      permission = "character",
-      private    = "logical",
       creator    = "character",
       created_at = "POSIXct",
       updated_at = "POSIXct",
@@ -370,20 +366,44 @@ test_that("view_project returns a list of project properties", {
   expect_identical(attr(org_project, "status"), 200L)
   expect_identical(
     map_chr(org_project, ~ class(.)[[1]]),
-    c(id         = "integer",
-      number     = "integer",
-      name       = "character",
-      body       = "character",
-      state      = "character",
-      permission = "character",
-      private    = "logical",
-      creator    = "character",
-      created_at = "POSIXct",
-      updated_at = "POSIXct",
-      html_url   = "character"))
+    c(id             = "integer",
+      number         = "integer",
+      name           = "character",
+      body           = "character",
+      state          = "character",
+      private        = "logical",
+      org_permission = "character",
+      creator        = "character",
+      created_at     = "POSIXct",
+      updated_at     = "POSIXct",
+      html_url       = "character"))
 
-  expect_identical(org_project$permission, "read")
+  expect_identical(org_project$org_permission, "read")
   expect_identical(org_project$private, FALSE)
+
+  team_project <- view_project(
+    project = "Organization project",
+    team    = "TestProjectsTeam",
+    org     = "HairyCoos")
+
+  expect_is(team_project, "list")
+  expect_identical(attr(team_project, "status"), 200L)
+  expect_identical(
+    map_chr(team_project, ~ class(.)[[1]]),
+    c(id              = "integer",
+      number          = "integer",
+      name            = "character",
+      body            = "character",
+      state           = "character",
+      private         = "logical",
+      org_permission  = "character",
+      team_permission = "character",
+      creator         = "character",
+      created_at      = "POSIXct",
+      updated_at      = "POSIXct",
+      html_url        = "character"))
+
+  expect_identical(team_project$team_permission, "read")
 
 })
 
@@ -402,8 +422,6 @@ test_that("view_project can accept a project number", {
       name       = "character",
       body       = "character",
       state      = "character",
-      permission = "character",
-      private    = "logical",
       creator    = "character",
       created_at = "POSIXct",
       updated_at = "POSIXct",

--- a/tests/testthat/test-projects.R
+++ b/tests/testthat/test-projects.R
@@ -1,16 +1,24 @@
 context("projects api")
 
 
-setup(try(silent = TRUE, {
+# SETUP ---------------------------------------------------------------------------------------
+
+now <- format(Sys.time(), "%Y%m%d-%H%M%S")
+
+setup(suppressMessages(try(silent = TRUE, {
+
   test_team <- create_team(
-    name        = "TestProjectsTeam",
+    name        = paste("Test projects", now),
     description = "This was created to test team projects",
     org         = "HairyCoos")
-}))
 
-teardown(try(silent = TRUE, {
-  delete_team("TestProjectsTeam", org = "HairyCoos")
-}))
+})))
+
+teardown(suppressMessages(try(silent = TRUE, {
+
+  delete_team(paste("Test projects", now), org = "HairyCoos")
+
+})))
 
 
 # TEST: create_project ------------------------------------------------------------------------
@@ -18,7 +26,7 @@ teardown(try(silent = TRUE, {
 test_that("create_projects creates a project and returns its properties", {
 
   repo_project <- create_project(
-    name = "Repo project",
+    name = paste("Repo project", now),
     body = "This is a repo project",
     repo = "ChadGoymer/test-githapi")
 
@@ -36,10 +44,10 @@ test_that("create_projects creates a project and returns its properties", {
       updated_at = "POSIXct",
       html_url   = "character"))
 
-  expect_identical(repo_project$name, "Repo project")
+  expect_identical(repo_project$name, paste("Repo project", now))
 
   user_project <- create_project(
-    name = "User project",
+    name = paste("User project", now),
     body = "This is a user project")
 
   expect_is(user_project, "list")
@@ -56,10 +64,10 @@ test_that("create_projects creates a project and returns its properties", {
       updated_at = "POSIXct",
       html_url   = "character"))
 
-  expect_identical(user_project$name, "User project")
+  expect_identical(user_project$name, paste("User project", now))
 
   org_project <- create_project(
-    name = "Organization project",
+    name = paste("Organization project", now),
     body = "This is an organization project",
     org  = "HairyCoos")
 
@@ -79,7 +87,7 @@ test_that("create_projects creates a project and returns its properties", {
       updated_at     = "POSIXct",
       html_url       = "character"))
 
-  expect_identical(org_project$name, "Organization project")
+  expect_identical(org_project$name, paste("Organization project", now))
 
 })
 
@@ -109,8 +117,8 @@ test_that("create_project throws an error if invalid arguments are supplied", {
 test_that("update_project updates a project and returns a list of the new properties", {
 
   repo_project <- update_project(
-    project = "Repo project",
-    name    = "Updated repo project",
+    project = paste("Repo project", now),
+    name    = paste("Updated repo project", now),
     body    = "This is an updated repo project",
     repo    = "ChadGoymer/test-githapi")
 
@@ -128,10 +136,10 @@ test_that("update_project updates a project and returns a list of the new proper
       updated_at = "POSIXct",
       html_url   = "character"))
 
-  expect_identical(repo_project$name, "Updated repo project")
+  expect_identical(repo_project$name, paste("Updated repo project", now))
 
   user_project <- update_project(
-    project = "User project",
+    project = paste("User project", now),
     state   = "closed",
     user    = "ChadGoymer")
 
@@ -152,7 +160,7 @@ test_that("update_project updates a project and returns a list of the new proper
   expect_identical(user_project$state, "closed")
 
   org_project <- update_project(
-    project    = "Organization project",
+    project    = paste("Organization project", now),
     permission = "read",
     private    = FALSE,
     org        = "HairyCoos")
@@ -177,8 +185,8 @@ test_that("update_project updates a project and returns a list of the new proper
   expect_identical(org_project$private, FALSE)
 
   team_project <- update_project(
-    project = "Organization project",
-    team    = "TestProjectsTeam",
+    project = paste("Organization project", now),
+    team    = paste("Test projects", now),
     org     = "HairyCoos")
 
   expect_is(team_project, "list")
@@ -201,8 +209,8 @@ test_that("update_project updates a project and returns a list of the new proper
   expect_identical(team_project$team_permission, "write")
 
   upd_team_project <- update_project(
-    project    = "Organization project",
-    team       = "TestProjectsTeam",
+    project    = paste("Organization project", now),
+    team       = paste("Test projects", now),
     org        = "HairyCoos",
     permission = "read")
 
@@ -248,7 +256,7 @@ test_that("view_projects returns a tibble summarising the projects", {
       updated_at = "POSIXct",
       html_url   = "character"))
 
-  expect_true("Updated repo project" %in% repo_projects$name)
+  expect_true(paste("Updated repo project", now) %in% repo_projects$name)
 
   user_projects <- view_projects(user = "ChadGoymer", state = "closed")
 
@@ -266,7 +274,7 @@ test_that("view_projects returns a tibble summarising the projects", {
       updated_at = "POSIXct",
       html_url   = "character"))
 
-  expect_true("User project" %in% user_projects$name)
+  expect_true(paste("User project", now) %in% user_projects$name)
 
   org_projects <- view_projects(org = "HairyCoos")
 
@@ -286,9 +294,9 @@ test_that("view_projects returns a tibble summarising the projects", {
       updated_at     = "POSIXct",
       html_url       = "character"))
 
-  expect_true("Organization project" %in% org_projects$name)
+  expect_true(paste("Organization project", now) %in% org_projects$name)
 
-  team_projects <- view_projects(team = "TestProjectsTeam", org = "HairyCoos")
+  team_projects <- view_projects(team = paste("Test projects", now), org = "HairyCoos")
 
   expect_is(team_projects, "tbl")
   expect_identical(attr(team_projects, "status"), 200L)
@@ -307,7 +315,7 @@ test_that("view_projects returns a tibble summarising the projects", {
       updated_at      = "POSIXct",
       html_url        = "character"))
 
-  expect_true("Organization project" %in% team_projects$name)
+  expect_true(paste("Organization project", now) %in% team_projects$name)
 
 })
 
@@ -324,7 +332,9 @@ test_that("view_projects throws an error if invalid arguments are supplied", {
 
 test_that("view_project returns a list of project properties", {
 
-  repo_project <- view_project("Updated repo project", repo = "ChadGoymer/test-githapi")
+  repo_project <- view_project(
+    project = paste("Updated repo project", now),
+    repo    = "ChadGoymer/test-githapi")
 
   expect_is(repo_project, "list")
   expect_identical(attr(repo_project, "status"), 200L)
@@ -340,9 +350,9 @@ test_that("view_project returns a list of project properties", {
       updated_at = "POSIXct",
       html_url   = "character"))
 
-  expect_identical(repo_project$name, "Updated repo project")
+  expect_identical(repo_project$name, paste("Updated repo project", now))
 
-  user_project <- view_project("User project", user = "ChadGoymer")
+  user_project <- view_project(paste("User project", now), user = "ChadGoymer")
 
   expect_is(user_project, "list")
   expect_identical(attr(user_project, "status"), 200L)
@@ -360,7 +370,7 @@ test_that("view_project returns a list of project properties", {
 
   expect_identical(user_project$state, "closed")
 
-  org_project <- view_project("Organization project", org = "HairyCoos")
+  org_project <- view_project(paste("Organization project", now), org = "HairyCoos")
 
   expect_is(org_project, "list")
   expect_identical(attr(org_project, "status"), 200L)
@@ -382,8 +392,8 @@ test_that("view_project returns a list of project properties", {
   expect_identical(org_project$private, FALSE)
 
   team_project <- view_project(
-    project = "Organization project",
-    team    = "TestProjectsTeam",
+    project = paste("Organization project", now),
+    team    = paste("Test projects", now),
     org     = "HairyCoos")
 
   expect_is(team_project, "list")
@@ -438,7 +448,7 @@ test_that("view_project throws an error if invalid arguments are supplied", {
     "'project' must be either an integer or a string")
 
   expect_error(
-    view_project("Repo project"),
+    view_project(paste("Repo project", now)),
     "Must specify either 'repo', 'user' or 'org'!")
 
 })
@@ -450,27 +460,29 @@ test_that("browse_project opens the project in the browser", {
 
   skip_if(!interactive(), "browse_project must be tested manually")
 
-  repo_project <- browse_project("Updated repo project", repo = "ChadGoymer/test-githapi")
+  repo_project <- browse_project(
+    project = paste("Updated repo project", now),
+    repo    = "ChadGoymer/test-githapi")
 
   expect_is(repo_project, "character")
   expect_identical(attr(repo_project, "status"), 200L)
   expect_identical(dirname(repo_project), "https://github.com/ChadGoymer/test-githapi/projects")
 
-  user_project <- browse_project("User project", user = "ChadGoymer")
+  user_project <- browse_project(paste("User project", now), user = "ChadGoymer")
 
   expect_is(user_project, "character")
   expect_identical(attr(user_project, "status"), 200L)
   expect_identical(dirname(user_project), "https://github.com/users/ChadGoymer/projects")
 
-  org_project <- browse_project("Organization project", org = "HairyCoos")
+  org_project <- browse_project(paste("Organization project", now), org = "HairyCoos")
 
   expect_is(org_project, "character")
   expect_identical(attr(org_project, "status"), 200L)
   expect_identical(dirname(org_project), "https://github.com/orgs/HairyCoos/projects")
 
   team_project <- browse_project(
-    project = "Organization project",
-    team    = "TestProjectsTeam",
+    project = paste("Organization project", now),
+    team    = paste("Test projects", now),
     org     = "HairyCoos")
 
   expect_is(team_project, "character")
@@ -484,28 +496,30 @@ test_that("browse_project opens the project in the browser", {
 
 test_that("delete_project deletes the projects and returns TRUE", {
 
-  repo_project <- delete_project("Updated repo project", repo = "ChadGoymer/test-githapi")
+  repo_project <- delete_project(
+    project = paste("Updated repo project", now),
+    repo    = "ChadGoymer/test-githapi")
 
   expect_is(repo_project, "logical")
   expect_identical(attr(repo_project, "status"), 204L)
   expect_identical(as.logical(repo_project), TRUE)
 
-  user_project <- delete_project("User project", user = "ChadGoymer")
+  user_project <- delete_project(paste("User project", now), user = "ChadGoymer")
 
   expect_is(user_project, "logical")
   expect_identical(attr(user_project, "status"), 204L)
   expect_identical(as.logical(user_project), TRUE)
 
   team_project <- delete_project(
-    project = "Organization project",
-    team    = "TestProjectsTeam",
+    project = paste("Organization project", now),
+    team    = paste("Test projects", now),
     org     = "HairyCoos")
 
   expect_is(team_project, "logical")
   expect_identical(attr(team_project, "status"), 204L)
   expect_identical(as.logical(team_project), TRUE)
 
-  org_project <- delete_project("Organization project", org = "HairyCoos")
+  org_project <- delete_project(paste("Organization project", now), org = "HairyCoos")
 
   expect_is(org_project, "logical")
   expect_identical(attr(org_project, "status"), 204L)

--- a/tests/testthat/test-teams.R
+++ b/tests/testthat/test-teams.R
@@ -1,12 +1,17 @@
 context("teams api")
 
 
+# SETUP ---------------------------------------------------------------------------------------
+
+now <- format(Sys.time(), "%Y%m%d-%H%M%S")
+
+
 # TEST: create_team ------------------------------------------------------------------------
 
 test_that("create_team creates a team and returns its properties", {
 
   first_team <- create_team(
-    name        = "TestTeam",
+    name        = paste("Test team", now),
     org         = "HairyCoos",
     description = "This is a test team",
     repo_names  = "HairyCoos/test-repo")
@@ -29,12 +34,15 @@ test_that("create_team creates a team and returns its properties", {
       created_at    = "POSIXct",
       updated_at    = "POSIXct"))
 
-  expect_identical(first_team$name, "TestTeam")
+  expect_identical(first_team$name, paste("Test team", now))
   expect_identical(first_team$organization, "HairyCoos")
   expect_identical(first_team$description, "This is a test team")
   expect_identical(first_team$repos_count, 1L)
 
-  maintainers_team <- create_team("TestTeam2", "HairyCoos", maintainers = "ChadGoymer")
+  maintainers_team <- create_team(
+    name        = paste("Test team 2", now),
+    org         = "HairyCoos",
+    maintainers = "ChadGoymer")
 
   expect_is(maintainers_team, "list")
   expect_identical(attr(maintainers_team, "status"), 201L)
@@ -54,11 +62,14 @@ test_that("create_team creates a team and returns its properties", {
       created_at    = "POSIXct",
       updated_at    = "POSIXct"))
 
-  expect_identical(maintainers_team$name, "TestTeam2")
+  expect_identical(maintainers_team$name, paste("Test team 2", now))
   expect_identical(maintainers_team$organization, "HairyCoos")
   expect_identical(maintainers_team$members_count, 1L)
 
-  closed_team <- create_team("TestTeam3", "HairyCoos", privacy = "closed")
+  closed_team <- create_team(
+    name    = paste("Test team 3", now),
+    org     = "HairyCoos",
+    privacy = "closed")
 
   expect_is(closed_team, "list")
   expect_identical(attr(closed_team, "status"), 201L)
@@ -78,11 +89,14 @@ test_that("create_team creates a team and returns its properties", {
       created_at    = "POSIXct",
       updated_at    = "POSIXct"))
 
-  expect_identical(closed_team$name, "TestTeam3")
+  expect_identical(closed_team$name, paste("Test team 3", now))
   expect_identical(closed_team$organization, "HairyCoos")
   expect_identical(closed_team$privacy, "closed")
 
-  parent_team <- create_team("TestTeam4", "HairyCoos", parent_team = "TestTeam3")
+  parent_team <- create_team(
+    name        = paste("Test team 4", now),
+    org         = "HairyCoos",
+    parent_team = paste("Test team 3", now))
 
   expect_is(parent_team, "list")
   expect_identical(attr(parent_team, "status"), 201L)
@@ -102,9 +116,9 @@ test_that("create_team creates a team and returns its properties", {
       created_at    = "POSIXct",
       updated_at    = "POSIXct"))
 
-  expect_identical(parent_team$name, "TestTeam4")
+  expect_identical(parent_team$name, paste("Test team 4", now))
   expect_identical(parent_team$organization, "HairyCoos")
-  expect_identical(parent_team$parent, "TestTeam3")
+  expect_identical(parent_team$parent, paste("Test team 3", now))
 
 })
 
@@ -113,15 +127,15 @@ test_that("create_team creates a team and returns its properties", {
 
 test_that("update_team changes the team's properties", {
 
-  original_team <- view_team("TestTeam", "HairyCoos")
+  original_team <- view_team(paste("Test team", now), "HairyCoos")
 
   updated_team <- update_team(
-    team        = "TestTeam",
-    name        = "FirstTeam",
+    team        = paste("Test team", now),
+    name        = paste("First test team", now),
     org         = "HairyCoos",
     description = "This is a test team",
     privacy     = "closed",
-    parent_team = "TestTeam3")
+    parent_team = paste("Test team 3", now))
 
   expect_is(updated_team, "list")
   expect_identical(attr(updated_team, "status"), 200L)
@@ -141,10 +155,10 @@ test_that("update_team changes the team's properties", {
       created_at    = "POSIXct",
       updated_at    = "POSIXct"))
 
-  expect_identical(updated_team$name, "FirstTeam")
+  expect_identical(updated_team$name, paste("First test team", now))
   expect_identical(updated_team$description, "This is a test team")
   expect_identical(updated_team$privacy, "closed")
-  expect_identical(updated_team$parent, "TestTeam3")
+  expect_identical(updated_team$parent, paste("Test team 3", now))
 
 })
 
@@ -168,9 +182,9 @@ test_that("view_teams returns a tibble summarising the teams", {
       parent        = "character",
       html_url      = "character"))
 
-  expect_true("FirstTeam" %in% org_teams$name)
+  expect_true(paste("First test team", now) %in% org_teams$name)
 
-  team_teams <- view_teams("HairyCoos", parent_team = "TestTeam3")
+  team_teams <- view_teams("HairyCoos", parent_team = paste("Test team 3", now))
 
   expect_is(team_teams, "tbl")
   expect_identical(attr(team_teams, "status"), 200L)
@@ -185,7 +199,7 @@ test_that("view_teams returns a tibble summarising the teams", {
       parent        = "character",
       html_url      = "character"))
 
-  expect_true("FirstTeam" %in% team_teams$name)
+  expect_true(paste("First test team", now) %in% team_teams$name)
 
   user_teams <- view_teams()
 
@@ -202,7 +216,7 @@ test_that("view_teams returns a tibble summarising the teams", {
       parent        = "character",
       html_url      = "character"))
 
-  expect_true("FirstTeam" %in% user_teams$name)
+  expect_true(paste("First test team", now) %in% user_teams$name)
 
 })
 
@@ -211,7 +225,7 @@ test_that("view_teams returns a tibble summarising the teams", {
 
 test_that("view_team returns a list of team properties", {
 
-  team <- view_team("FirstTeam", "HairyCoos")
+  team <- view_team(paste("First test team", now), "HairyCoos")
 
   expect_is(team, "list")
   expect_identical(attr(team, "status"), 200L)
@@ -231,7 +245,7 @@ test_that("view_team returns a list of team properties", {
       created_at    = "POSIXct",
       updated_at    = "POSIXct"))
 
-  expect_identical(team$name, "FirstTeam")
+  expect_identical(team$name, paste("First test team", now))
 
   team_by_id <- view_team(team$id)
 
@@ -253,7 +267,7 @@ test_that("view_team returns a list of team properties", {
       created_at    = "POSIXct",
       updated_at    = "POSIXct"))
 
-  expect_identical(team_by_id$name, "FirstTeam")
+  expect_identical(team_by_id$name, paste("First test team", now))
 
 })
 
@@ -264,19 +278,23 @@ test_that("browse_team opens the team's page in the browser", {
 
   skip_if(!interactive(), "browse_team must be tested manually")
 
-  team <- browse_team("FirstTeam", "HairyCoos")
+  team <- browse_team(paste("First test team", now), "HairyCoos")
 
   expect_is(team, "character")
   expect_identical(attr(team, "status"), 200L)
-  expect_identical(as.character(team), "https://github.com/orgs/HairyCoos/teams/firstteam")
+  expect_identical(
+    as.character(team),
+    paste0("https://github.com/orgs/HairyCoos/teams/first-test-team-", now))
 
 
-  team <- view_team("FirstTeam", "HairyCoos")
+  team <- view_team(paste("First test team", now), "HairyCoos")
   team_by_id <- browse_team(team$id)
 
   expect_is(team_by_id, "character")
   expect_identical(attr(team_by_id, "status"), 200L)
-  expect_identical(as.character(team_by_id), "https://github.com/orgs/HairyCoos/teams/firstteam")
+  expect_identical(
+    as.character(team_by_id),
+    paste0("https://github.com/orgs/HairyCoos/teams/first-test-team-", now))
 
   expect_error(browse_team(FALSE), "'team' must be an integer or string")
 
@@ -287,19 +305,19 @@ test_that("browse_team opens the team's page in the browser", {
 
 test_that("delete_team removes a team from an organization", {
 
-  first_team <- delete_team("FirstTeam", "HairyCoos")
+  first_team <- delete_team(paste("First test team", now), "HairyCoos")
 
   expect_is(first_team, "logical")
   expect_identical(attr(first_team, "status"), 204L)
   expect_identical(as.logical(first_team), TRUE)
 
-  secret_team <- delete_team("TestTeam2", "HairyCoos")
+  secret_team <- delete_team(paste("Test team 2", now), "HairyCoos")
 
   expect_is(secret_team, "logical")
   expect_identical(attr(secret_team, "status"), 204L)
   expect_identical(as.logical(secret_team), TRUE)
 
-  parent_team <- delete_team("TestTeam3", "HairyCoos")
+  parent_team <- delete_team(paste("Test team 3", now), "HairyCoos")
 
   expect_is(parent_team, "logical")
   expect_identical(attr(parent_team, "status"), 204L)


### PR DESCRIPTION
## Summary

Updated the following functions:
- `create_project()`: Only include organization properties if organization project is created
- `update_project()`: Add or update team permissions on an organization project
- `view_projects()`: View the projects a team has access to
- `view_project()`: View a project a team has access to
- `browse_project()`: Browse a project a team has access to
- `delete_project()`: Remove a team from an organization project

Resolves: #159 
