### PR TITLE
196 fix pkgdown workflow

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -7,12 +7,17 @@ name: pkgdown
 jobs:
   pkgdown:
     runs-on: macOS-latest
+
     env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - uses: actions/checkout@v2
 
       - uses: r-lib/actions/setup-r@master
+        with:
+          r-version: 'release'
 
       - uses: r-lib/actions/setup-pandoc@master
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: githapi
 Title: User-friendly access to the GitHub API for R, consistent with the tidyverse
-Version: 0.10.3
+Version: 0.10.4
 Authors@R: person("Chad", "Goymer", email = "chad.goymer@lloyds.com", role = c("aut", "cre"))
 Description: Provides a suite of functions which simplify working with GitHub's API.
 Imports:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# githapi 0.10.4
+
+- Set R version to 'release' for pkgdown workflow
+
 # githapi 0.10.3
 
 - Added `update_team_repository()`


### PR DESCRIPTION
## Summary

Set R version to 'release' for pkgdown workflow

Resolves: #196
