### PR TITLE
Set git credentials for deploying pkgdown docs

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -46,5 +46,7 @@ jobs:
         run: R CMD INSTALL .
 
       - name: Deploy package
-        run: pkgdown::deploy_to_branch(new_process = FALSE)
-        shell: Rscript {0}
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'


### PR DESCRIPTION
## Summary

Updated the pkgdown workflow by setting the git credentials when deploying to the gh-pages branch

Resolves: #208 
