### PR TITLE
211 fix labels with spaces

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: githapi
 Title: User-friendly access to the GitHub API for R, consistent with the tidyverse
-Version: 0.10.11
+Version: 0.10.12
 Authors@R: person("Chad", "Goymer", email = "chad.goymer@lloyds.com", role = c("aut", "cre"))
 Description: Provides a suite of functions which simplify working with GitHub's API.
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,7 @@ Imports:
     methods,
     grDevices,
     jsonlite,
+    curl,
     httr,
     rlang,
     stringr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# githapi 0.10.12
+
+- Fixed bug label functions so they work with spaces in names
+- Updated `gh_url()` so it encodes URLs
+
 # githapi 0.10.11
 
 - Removed all references to "master" in functions and documentation

--- a/R/github-api.R
+++ b/R/github-api.R
@@ -142,28 +142,51 @@ gh_url <- function(
 {
   assert(is_url(api), "'api' must be a valid URL:\n  ", api)
 
-  url  <- httr::parse_url(api)
-
   dots <- list(...) %>% compact() %>% unlist()
 
-  if (is_null(names(dots))) {
-    path <- str_c(dots, collapse = "/")
+  path <- dots
+  if (!is_null(names(path))) {
+    path <- path[names(path) == ""]
   }
-  else {
-    path <- str_c(dots[names(dots) == ""], collapse = "/")
-  }
-
-  if (!identical(length(path), 0L)) {
-    url$path <- file.path(url$path, path)
-  }
-
-  query <- as.list(dots[names(dots) != ""])
-
-  if (!identical(length(query), 0L)) {
-    url$query <- query
+  if (!is.null(path)) {
+    path <- str_c(path, collapse = "/") %>%
+      str_split("/") %>%
+      first() %>%
+      map(curl::curl_escape) %>%
+      str_c(collapse = "/")
   }
 
-  httr::build_url(url)
+  query <- dots[names(dots) != ""]
+  if (!is.null(query)) {
+    query <- as.list(query)
+  }
+
+  httr::modify_url(url = api, path = path, query = query)
+  #
+  #
+  #
+  # url  <- httr::parse_url(api)
+  #
+  # dots <- list(...) %>% compact() %>% unlist()
+  #
+  # if (is_null(names(dots))) {
+  #   path <- str_c(dots, collapse = "/")
+  # }
+  # else {
+  #   path <- str_c(dots[names(dots) == ""], collapse = "/")
+  # }
+  #
+  # if (!identical(length(path), 0L)) {
+  #   url$path <- file.path(url$path, path)
+  # }
+  #
+  # query <- as.list(dots[names(dots) != ""])
+  #
+  # if (!identical(length(query), 0L)) {
+  #   url$query <- query
+  # }
+  #
+  # httr::build_url(url)
 }
 
 

--- a/tests/testthat/test-github-api.R
+++ b/tests/testthat/test-github-api.R
@@ -102,6 +102,8 @@ test_that("gh_token throws an error if an invalid token is specified", {
 
 test_that("gh_url returns a valid URL for the GitHub API", {
 
+  expect_identical(gh_url(), str_c(getOption("github.api"), "/"))
+
   expect_identical(
     gh_url("repos"),
     file.path(getOption("github.api"), "repos"))
@@ -133,6 +135,10 @@ test_that("gh_url returns a valid URL for the GitHub API", {
   expect_identical(
     gh_url(c("repos", "ChadGoymer/githapi", "git/trees", "234752384"), list()),
     file.path(getOption("github.api"), "repos/ChadGoymer/githapi/git/trees/234752384"))
+
+  expect_identical(
+    gh_url("repos", "ChadGoymer/githapi", "labels", "simple label", type = "some type"),
+    file.path(getOption("github.api"), "repos/ChadGoymer/githapi/labels/simple%20label?type=some%20type"))
 
 })
 

--- a/tests/testthat/test-labels.R
+++ b/tests/testthat/test-labels.R
@@ -30,7 +30,7 @@ teardown(suppressMessages({
 test_that("create_label creates a label and returns a list of the properties", {
 
   simple_label <- create_label(
-    name  = "simple-label",
+    name  = "simple label",
     repo  = str_c("ChadGoymer/test-labels-", suffix),
     color = "blue")
 
@@ -42,7 +42,7 @@ test_that("create_label creates a label and returns a list of the properties", {
       color       = "character",
       description = "character"))
 
-  expect_identical(simple_label$name, "simple-label")
+  expect_identical(simple_label$name, "simple label")
   expect_identical(simple_label$color, "0000FF")
 
   detailed_label <- create_label(
@@ -71,9 +71,9 @@ test_that("create_label creates a label and returns a list of the properties", {
 test_that("update_label changes a label and returns a list of the properties", {
 
   updated_label <- update_label(
-    label       = "simple-label",
+    label       = "simple label",
     repo        = str_c("ChadGoymer/test-labels-", suffix),
-    name        = "updated-label",
+    name        = "updated label",
     color       = "pink",
     description = "This is an updated label")
 
@@ -85,7 +85,7 @@ test_that("update_label changes a label and returns a list of the properties", {
       color       = "character",
       description = "character"))
 
-  expect_identical(updated_label$name, "updated-label")
+  expect_identical(updated_label$name, "updated label")
   expect_identical(updated_label$color, "FFC0CB")
   expect_identical(updated_label$description, "This is an updated label")
 
@@ -97,7 +97,7 @@ test_that("update_label changes a label and returns a list of the properties", {
 test_that("add_labels adds labels to an issue and returns the properties", {
 
   added_labels <- add_labels(
-    labels = c("updated-label", "detailed-label"),
+    labels = c("updated label", "detailed-label"),
     issue  = str_c("test labels ", suffix),
     repo   = str_c("ChadGoymer/test-labels-", suffix))
 
@@ -109,7 +109,7 @@ test_that("add_labels adds labels to an issue and returns the properties", {
       color       = "character",
       description = "character"))
 
-  expect_true(all(c("updated-label", "detailed-label") %in% added_labels$name))
+  expect_true(all(c("updated label", "detailed-label") %in% added_labels$name))
 
 })
 
@@ -128,7 +128,7 @@ test_that("view_labels returns a tibble of label properties", {
       color       = "character",
       description = "character"))
 
-  expect_true(all(c("updated-label", "detailed-label") %in% repo_labels$name))
+  expect_true(all(c("updated label", "detailed-label") %in% repo_labels$name))
 
   issue_labels <- view_labels(
     issue = str_c("test labels ", suffix),
@@ -143,7 +143,7 @@ test_that("view_labels returns a tibble of label properties", {
       color       = "character",
       description = "character"))
 
-  expect_true(all(c("updated-label", "detailed-label") %in% issue_labels$name))
+  expect_true(all(c("updated label", "detailed-label") %in% issue_labels$name))
 
 })
 
@@ -172,7 +172,7 @@ test_that("view_label returns a list of repository properties", {
 test_that("add_labels adds labels to an issue and returns the properties", {
 
   removed_labels <- remove_labels(
-    labels = c("updated-label", "detailed-label"),
+    labels = c("updated label", "detailed-label"),
     issue  = str_c("test labels ", suffix),
     repo   = str_c("ChadGoymer/test-labels-", suffix))
 
@@ -193,7 +193,7 @@ test_that("add_labels adds labels to an issue and returns the properties", {
 
 test_that("delete_label removes a label and returns TRUE", {
 
-  updated_label <- delete_label("updated-label", repo = str_c("ChadGoymer/test-labels-", suffix))
+  updated_label <- delete_label("updated label", repo = str_c("ChadGoymer/test-labels-", suffix))
 
   expect_is(updated_label, "logical")
   expect_identical(attr(updated_label, "status"), 204L)


### PR DESCRIPTION
## Summary

- Fixed bug label functions so they work with spaces in names
- Updated `gh_url()` so it encodes URLs

Resolves: #211 
