### PR TITLE
218 fix incorrect url

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: githapi
 Title: User-friendly access to the GitHub API for R, consistent with the tidyverse
-Version: 0.10.12
+Version: 0.10.13
 Authors@R: person("Chad", "Goymer", email = "chad.goymer@lloyds.com", role = c("aut", "cre"))
 Description: Provides a suite of functions which simplify working with GitHub's API.
 Imports:
@@ -17,15 +17,15 @@ Imports:
     dplyr,
     readr,
     msgr
-Roxygen: list(markdown = TRUE)
-License: MIT + file LICENSE
-Encoding: UTF-8
-Language: En-GB
-LazyData: true
 Suggests: 
     httpuv,
     testthat,
     covr
+Encoding: UTF-8
+Language: En-GB
+License: MIT + file LICENSE
+Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.0
+LazyData: true
 URL: https://github.com/ChadGoymer/githapi
 BugReports: https://github.com/ChadGoymer/githapi/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
+# githapi 0.10.13
+
+- Fixed bug with `gh_url()` for GitHub Enterprise
+
 # githapi 0.10.12
 
-- Fixed bug label functions so they work with spaces in names
+- Fixed bug with label functions so they work with spaces in names
 - Updated `gh_url()` so it encodes URLs
 
 # githapi 0.10.11

--- a/R/github-api.R
+++ b/R/github-api.R
@@ -154,6 +154,11 @@ gh_url <- function(
       first() %>%
       map(curl::curl_escape) %>%
       str_c(collapse = "/")
+
+    parsed_api <- httr::parse_url(api)
+    if (!is_null(parsed_api$path)) {
+      path <- str_c(parsed_api$path, "/", path)
+    }
   }
 
   query <- dots[names(dots) != ""]


### PR DESCRIPTION
## Summary

Fixed bug with `gh_url()` for GitHub Enterprise

Resolves: #218
