### PR TITLE
241 fix upload commit error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: githapi
 Title: User-friendly access to the GitHub API for R, consistent with the tidyverse
-Version: 0.10.22
+Version: 0.10.23
 Authors@R: person("Chad", "Goymer", email = "chad.goymer@gmail.com", role = c("aut", "cre"))
 Description: Provides a suite of functions which simplify working with GitHub's API.
 Imports:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# githapi 0.10.23
+
+- Ignore empty directories when uploading a commit (or tree)
+
 # githapi 0.10.22
 
 - Only set githapi options on-load if they are not already set

--- a/R/files.R
+++ b/R/files.R
@@ -147,7 +147,7 @@ upload_tree <- function(
       path = basename(path)
     ) %>%
     select("path", "mode", "type", "sha") %>%
-    filter(!is.na(sha))
+    filter(!is.na(.data$sha))
 
   payload <- tibble(
     path = tree$path,

--- a/R/files.R
+++ b/R/files.R
@@ -115,8 +115,11 @@ upload_tree <- function(
     include.dirs = TRUE,
     full.names   = TRUE
   ) %>%
-    discard(~ basename(.) %in% ignore) %>%
-    file.info() %>%
+    discard(~ basename(.) %in% ignore)
+
+  if (length(tree) == 0) return(list(tree_sha = NA))
+
+  tree <- file.info(tree) %>%
     rownames_to_column("path") %>%
     mutate(sha = map2_chr(.data$path, .data$isdir, function(path, isdir) {
       if (isdir) {
@@ -143,7 +146,8 @@ upload_tree <- function(
       mode = ifelse(.data$isdir, "040000", "100644"),
       path = basename(path)
     ) %>%
-    select("path", "mode", "type", "sha")
+    select("path", "mode", "type", "sha") %>%
+    filter(!is.na(sha))
 
   payload <- tibble(
     path = tree$path,

--- a/R/statuses.R
+++ b/R/statuses.R
@@ -35,7 +35,7 @@
 #'
 #' **Status Properties:**
 #'
-#' - **id**: The id of the release.
+#' - **id**: The id of the status.
 #' - **state**: The state of the status.
 #' - **description**: The description of the status.
 #' - **target_url**: The URL linked to the status.
@@ -168,7 +168,7 @@ create_status <- function(
 #'
 #' **Status Properties:**
 #'
-#' - **id**: The id of the release.
+#' - **id**: The id of the status.
 #' - **state**: The state of the status.
 #' - **description**: The description of the status.
 #' - **target_url**: The URL linked to the status.

--- a/man/create_status.Rd
+++ b/man/create_status.Rd
@@ -38,7 +38,7 @@ from the status of other systems. Default: \code{"default"}.}
 
 \strong{Status Properties:}
 \itemize{
-\item \strong{id}: The id of the release.
+\item \strong{id}: The id of the status.
 \item \strong{state}: The state of the status.
 \item \strong{description}: The description of the status.
 \item \strong{target_url}: The URL linked to the status.

--- a/man/view_statuses.Rd
+++ b/man/view_statuses.Rd
@@ -24,7 +24,7 @@ view_status(ref, repo, ...)
 
 \strong{Status Properties:}
 \itemize{
-\item \strong{id}: The id of the release.
+\item \strong{id}: The id of the status.
 \item \strong{state}: The state of the status.
 \item \strong{description}: The description of the status.
 \item \strong{target_url}: The URL linked to the status.

--- a/tests/testthat/test-commits.R
+++ b/tests/testthat/test-commits.R
@@ -132,6 +132,54 @@ test_that("upload_commit uploads files in a directory and creates a commit", {
   expect_identical(recursive_commit$message, "Commit to test upload_commit()")
 
 
+  empty_path <- file.path(temp_path, "empty")
+  empty_file_paths <- file.path(empty_path, c(
+    "dir-1/file-1.txt"
+  ))
+  file.path(empty_path, c(
+    "dir-1/dir-1-1"
+  )) %>%
+    walk(dir.create, recursive = TRUE)
+
+  walk(empty_file_paths, function(f) {
+    map_chr(
+      1:10,
+      ~sample(LETTERS, 10, replace = TRUE) %>% str_c(collapse = "")
+    ) %>%
+      writeLines(f)
+  })
+
+  empty_commit <- upload_commit(
+    path    = empty_path,
+    branch  = "main",
+    message = "Commit to test upload_commit()",
+    repo    = str_c("ChadGoymer/test-commits-", suffix)
+  )
+
+  expect_is(empty_commit, "list")
+  expect_identical(attr(empty_commit, "status"), 200L)
+  expect_identical(
+    map_chr(empty_commit, ~ class(.)[[1]]),
+    c(
+      sha             = "character",
+      message         = "character",
+      author_login    = "character",
+      author_name     = "character",
+      author_email    = "character",
+      author_date     = "POSIXct",
+      committer_login = "character",
+      committer_name  = "character",
+      committer_email = "character",
+      committer_date  = "POSIXct",
+      tree_sha        = "character",
+      parents         = "character",
+      html_url        = "character"
+    )
+  )
+
+  expect_identical(empty_commit$message, "Commit to test upload_commit()")
+
+
   author_commit <- upload_commit(
     path      = flat_path,
     branch    = "main",
@@ -395,54 +443,6 @@ test_that("upload_commit uploads files in a directory and creates a commit", {
     merge_branch_commit$parents,
     c(merge_main_commit$sha, new_branch_commit$sha)
   )
-
-
-  empty_path <- file.path(temp_path, "empty")
-  empty_file_paths <- file.path(empty_path, c(
-    "dir-1/file-1.txt"
-  ))
-  file.path(empty_path, c(
-    "dir-1/dir-1-1"
-  )) %>%
-    walk(dir.create, recursive = TRUE)
-
-  walk(empty_file_paths, function(f) {
-    map_chr(
-      1:10,
-      ~sample(LETTERS, 10, replace = TRUE) %>% str_c(collapse = "")
-    ) %>%
-      writeLines(f)
-  })
-
-  empty_commit <- upload_commit(
-    path    = empty_path,
-    branch  = "main",
-    message = "Commit to test upload_commit()",
-    repo    = str_c("ChadGoymer/test-commits-", suffix)
-  )
-
-  expect_is(empty_commit, "list")
-  expect_identical(attr(empty_commit, "status"), 200L)
-  expect_identical(
-    map_chr(empty_commit, ~ class(.)[[1]]),
-    c(
-      sha             = "character",
-      message         = "character",
-      author_login    = "character",
-      author_name     = "character",
-      author_email    = "character",
-      author_date     = "POSIXct",
-      committer_login = "character",
-      committer_name  = "character",
-      committer_email = "character",
-      committer_date  = "POSIXct",
-      tree_sha        = "character",
-      parents         = "character",
-      html_url        = "character"
-    )
-  )
-
-  expect_identical(empty_commit$message, "Commit to test upload_commit()")
 
 })
 

--- a/tests/testthat/test-commits.R
+++ b/tests/testthat/test-commits.R
@@ -396,6 +396,54 @@ test_that("upload_commit uploads files in a directory and creates a commit", {
     c(merge_main_commit$sha, new_branch_commit$sha)
   )
 
+
+  empty_path <- file.path(temp_path, "empty")
+  empty_file_paths <- file.path(empty_path, c(
+    "dir-1/file-1.txt"
+  ))
+  file.path(empty_path, c(
+    "dir-1/dir-1-1"
+  )) %>%
+    walk(dir.create, recursive = TRUE)
+
+  walk(empty_file_paths, function(f) {
+    map_chr(
+      1:10,
+      ~sample(LETTERS, 10, replace = TRUE) %>% str_c(collapse = "")
+    ) %>%
+      writeLines(f)
+  })
+
+  empty_commit <- upload_commit(
+    path    = empty_path,
+    branch  = "main",
+    message = "Commit to test upload_commit()",
+    repo    = str_c("ChadGoymer/test-commits-", suffix)
+  )
+
+  expect_is(empty_commit, "list")
+  expect_identical(attr(empty_commit, "status"), 200L)
+  expect_identical(
+    map_chr(empty_commit, ~ class(.)[[1]]),
+    c(
+      sha             = "character",
+      message         = "character",
+      author_login    = "character",
+      author_name     = "character",
+      author_email    = "character",
+      author_date     = "POSIXct",
+      committer_login = "character",
+      committer_name  = "character",
+      committer_email = "character",
+      committer_date  = "POSIXct",
+      tree_sha        = "character",
+      parents         = "character",
+      html_url        = "character"
+    )
+  )
+
+  expect_identical(empty_commit$message, "Commit to test upload_commit()")
+
 })
 
 

--- a/tests/testthat/test-files.R
+++ b/tests/testthat/test-files.R
@@ -217,6 +217,42 @@ test_that("upload_tree uploads a directory structure to github", {
   expect_null(ignore_tree$commit_sha)
   expect_true(is_sha(ignore_tree$tree_sha))
 
+
+  empty_path <- file.path(temp_path, "empty")
+  empty_file_paths <- file.path(empty_path, c(
+    "dir-1/file-1.txt"
+  ))
+  file.path(empty_path, c(
+    "dir-1/dir-1-1"
+  )) %>%
+    walk(dir.create, recursive = TRUE)
+
+  walk(empty_file_paths, function(f) {
+    map_chr(
+      1:10,
+      ~ sample(LETTERS, 10, replace = TRUE) %>% str_c(collapse = "")
+    ) %>%
+      writeLines(f)
+  })
+
+
+  empty_tree <- upload_tree(
+    path = empty_path,
+    repo = str_c("ChadGoymer/test-files-", suffix)
+  )
+
+  expect_is(empty_tree, "list")
+  expect_identical(
+    map_chr(empty_tree, ~ class(.)[[1]]),
+    c(
+      commit_sha = "NULL",
+      tree_sha   = "character"
+    )
+  )
+
+  expect_null(empty_tree$commit_sha)
+  expect_true(is_sha(empty_tree$tree_sha))
+
 })
 
 


### PR DESCRIPTION
## Summary

Ignore empty directories when uploading a commit (or tree)

Resolves: #241 
